### PR TITLE
fix(graph): Use provisional ID format for generated track IDs

### DIFF
--- a/backend/src/graph/normalizeReleaseBundle.js
+++ b/backend/src/graph/normalizeReleaseBundle.js
@@ -168,17 +168,21 @@ function normalizeTrackCatalog(trackDefs, errors) {
 /**
  * Generate deterministic track_id when missing
  *
+ * All generated IDs use the provisional format (prov:track:*) so that
+ * IdentityService.parseId() correctly classifies them as PROVISIONAL,
+ * ensuring consistent ID handling throughout the graph pipeline.
+ *
  * Priority:
- * 1. ISRC if available
+ * 1. ISRC if available (stored as property, ID is still provisional)
  * 2. Hash of normalized title + duration
  *
  * @param {Object} track - Normalized track
- * @returns {string} Deterministic track_id
+ * @returns {string} Deterministic track_id with prov: prefix
  */
 function generateTrackId(track) {
-    // Priority 1: ISRC-based ID
+    // Priority 1: ISRC-based provisional ID
     if (track.isrc) {
-        return `track:isrc:${track.isrc}`;
+        return `prov:track:isrc:${track.isrc}`;
     }
 
     // Priority 2: Hash of canonical identity (title + duration)
@@ -192,7 +196,7 @@ function generateTrackId(track) {
         .digest('hex')
         .substring(0, 16);
 
-    return `track:gen:${hash}`;
+    return `prov:track:${hash}`;
 }
 
 /**

--- a/backend/test/graph/normalizeReleaseBundle.test.js
+++ b/backend/test/graph/normalizeReleaseBundle.test.js
@@ -52,14 +52,14 @@ describe('normalizeReleaseBundle', () => {
             expect(normalized.tracks[0].title).toBe('Come Together');
             expect(normalized.tracks[1].title).toBe('Something');
 
-            // Each track should have track_id (ISRC-based)
-            expect(normalized.tracks[0].track_id).toBe('track:isrc:GBAYE0601729');
-            expect(normalized.tracks[1].track_id).toBe('track:isrc:GBAYE0601730');
+            // Each track should have track_id (ISRC-based provisional)
+            expect(normalized.tracks[0].track_id).toBe('prov:track:isrc:GBAYE0601729');
+            expect(normalized.tracks[1].track_id).toBe('prov:track:isrc:GBAYE0601730');
 
             // Tracklist should reference track_id
             expect(normalized.tracklist).toHaveLength(2);
-            expect(normalized.tracklist[0].track_id).toBe('track:isrc:GBAYE0601729');
-            expect(normalized.tracklist[1].track_id).toBe('track:isrc:GBAYE0601730');
+            expect(normalized.tracklist[0].track_id).toBe('prov:track:isrc:GBAYE0601729');
+            expect(normalized.tracklist[1].track_id).toBe('prov:track:isrc:GBAYE0601730');
             expect(normalized.tracklist[0].position).toBe('1');
         });
 
@@ -114,9 +114,9 @@ describe('normalizeReleaseBundle', () => {
 
             const normalized = normalizeReleaseBundle(bundle);
 
-            // Should generate track_id
+            // Should generate track_id with prov: prefix
             expect(normalized.tracks[0].track_id).toBeDefined();
-            expect(normalized.tracks[0].track_id).toMatch(/^track:gen:/);
+            expect(normalized.tracks[0].track_id).toMatch(/^prov:track:/);
 
             // Tracklist should reference generated track_id
             expect(normalized.tracklist[0].track_id).toBe(normalized.tracks[0].track_id);
@@ -166,7 +166,7 @@ describe('normalizeReleaseBundle', () => {
             const normalized = normalizeReleaseBundle(bundle);
 
             // Should match by title and add track_id to tracklist
-            expect(normalized.tracklist[0].track_id).toBe('track:isrc:ABC123');
+            expect(normalized.tracklist[0].track_id).toBe('prov:track:isrc:ABC123');
         });
 
         it('should error on tracklist item that cannot be resolved to catalog', () => {

--- a/scripts/smoke_payloads/create-release-bundle.tmpl.json
+++ b/scripts/smoke_payloads/create-release-bundle.tmpl.json
@@ -7,9 +7,29 @@
     "release": {
       "name": "Smoke Test Release __RUN_ID__"
     },
+    "groups": [
+      {
+        "name": "Smoke Test Band __RUN_ID__",
+        "members": [
+          {
+            "name": "Smoke Artist One __RUN_ID__",
+            "role": "Vocals"
+          },
+          {
+            "name": "Smoke Artist Two __RUN_ID__",
+            "role": "Guitar"
+          }
+        ]
+      }
+    ],
     "tracks": [
       {
-        "title": "Smoke Track __RUN_ID__"
+        "title": "Smoke Track __RUN_ID__",
+        "groups": [
+          {
+            "name": "Smoke Test Band __RUN_ID__"
+          }
+        ]
       }
     ],
     "tracklist": [


### PR DESCRIPTION
Change synthetic track IDs from 'track:gen:*' and 'track:isrc:*' to 'prov:track:*' format so IdentityService.parseId() correctly classifies them as PROVISIONAL. This ensures consistent ID handling throughout the graph pipeline, preventing ID mismatches that cause missing relationships.

Also update smoke test payload to include groups, persons, and performed_by_groups for better end-to-end testing of the graph structure.