### PR TITLE
Standardize timestamp placeholder to __TIMESTAMP__

### DIFF
--- a/backend/scripts/loadSmokeTests.js
+++ b/backend/scripts/loadSmokeTests.js
@@ -494,10 +494,15 @@ async function loadSmokeTests() {
                 const content = await readFile(filePath, 'utf8');
 
                 // Replace template placeholders with current timestamp
-                // Handle both __TIMESTAMP__ and "TIMESTAMP" (with quotes)
+                // Handle all timestamp formats:
+                // - __TIMESTAMP__ (double underscore, unquoted)
+                // - "TIMESTAMP" (quoted string)
+                // - TIMESTAMP (unquoted, no underscores)
+                const timestamp = Math.floor(Date.now() / 1000);
                 const processedContent = content
-                    .replace(/__TIMESTAMP__/g, Math.floor(Date.now() / 1000))
-                    .replace(/"TIMESTAMP"/g, Math.floor(Date.now() / 1000));
+                    .replace(/__TIMESTAMP__/g, timestamp)
+                    .replace(/"TIMESTAMP"/g, timestamp)
+                    .replace(/:\s*TIMESTAMP\s*,/g, `: ${timestamp},`);  // Unquoted TIMESTAMP
                 const bundle = JSON.parse(processedContent);
 
                 await processReleaseBundle(bundle, file);

--- a/backend/smoke-tests/releases/create-release-bundle-asking-friend.tmpl.json
+++ b/backend/smoke-tests/releases/create-release-bundle-asking-friend.tmpl.json
@@ -1,7 +1,7 @@
 {
 "v": 1,
 "type": "CREATE_RELEASE_BUNDLE",
-"created_at": "TIMESTAMP",
+"created_at": __TIMESTAMP__,
 "parents": [],
 "body": {
 "release": {

--- a/backend/smoke-tests/releases/create-release-bundle-audit-in-progress.tmpl.json
+++ b/backend/smoke-tests/releases/create-release-bundle-audit-in-progress.tmpl.json
@@ -1,7 +1,7 @@
 {
 "v": 1,
 "type": "CREATE_RELEASE_BUNDLE",
-"created_at": TIMESTAMP,
+"created_at": __TIMESTAMP__,
 "parents": [],
 "body": {
 "release": {

--- a/backend/smoke-tests/releases/create-release-bundle-automatic-midnight.tmpl.json
+++ b/backend/smoke-tests/releases/create-release-bundle-automatic-midnight.tmpl.json
@@ -1,7 +1,7 @@
 {
 "v": 1,
 "type": "CREATE_RELEASE_BUNDLE",
-"created_at": TIMESTAMP,
+"created_at": __TIMESTAMP__,
 "parents": [],
 "body": {
 "release": {

--- a/backend/smoke-tests/releases/create-release-bundle-autumn-seraphs.tmpl.json
+++ b/backend/smoke-tests/releases/create-release-bundle-autumn-seraphs.tmpl.json
@@ -1,7 +1,7 @@
 {
 "v": 1,
 "type": "CREATE_RELEASE_BUNDLE",
-"created_at": "TIMESTAMP",
+"created_at": __TIMESTAMP__,
 "parents": [],
 "body": {
 "release": {

--- a/backend/smoke-tests/releases/create-release-bundle-california.tmpl.json
+++ b/backend/smoke-tests/releases/create-release-bundle-california.tmpl.json
@@ -1,7 +1,7 @@
 {
 "v": 1,
 "type": "CREATE_RELEASE_BUNDLE",
-"created_at": "TIMESTAMP",
+"created_at": __TIMESTAMP__,
 "parents": [],
 "body": {
 "release": {

--- a/backend/smoke-tests/releases/create-release-bundle-group-sounds.tmpl.json
+++ b/backend/smoke-tests/releases/create-release-bundle-group-sounds.tmpl.json
@@ -1,7 +1,7 @@
 {
 "v": 1,
 "type": "CREATE_RELEASE_BUNDLE",
-"created_at": "TIMESTAMP",
+"created_at": __TIMESTAMP__,
 "parents": [],
 "body": {
 "release": {

--- a/backend/smoke-tests/releases/create-release-bundle-leave-no-ashes.tmpl.json
+++ b/backend/smoke-tests/releases/create-release-bundle-leave-no-ashes.tmpl.json
@@ -1,7 +1,7 @@
 {
 "v": 1,
 "type": "CREATE_RELEASE_BUNDLE",
-"created_at": TIMESTAMP,
+"created_at": __TIMESTAMP__,
 "parents": [],
 "body": {
 "release": {

--- a/backend/smoke-tests/releases/create-release-bundle-oblivion.tmpl.json
+++ b/backend/smoke-tests/releases/create-release-bundle-oblivion.tmpl.json
@@ -1,7 +1,7 @@
 {
 "v": 1,
 "type": "CREATE_RELEASE_BUNDLE",
-"created_at": "TIMESTAMP",
+"created_at": __TIMESTAMP__,
 "parents": [],
 "body": {
 "release": {

--- a/backend/smoke-tests/releases/create-release-bundle-off.tmpl.json
+++ b/backend/smoke-tests/releases/create-release-bundle-off.tmpl.json
@@ -1,7 +1,7 @@
 {
 "v": 1,
 "type": "CREATE_RELEASE_BUNDLE",
-"created_at": "TIMESTAMP",
+"created_at": __TIMESTAMP__,
 "parents": [],
 "body": {
 "release": {

--- a/backend/smoke-tests/releases/create-release-bundle-plosivs.tmpl.json
+++ b/backend/smoke-tests/releases/create-release-bundle-plosivs.tmpl.json
@@ -1,7 +1,7 @@
 {
 "v": 1,
 "type": "CREATE_RELEASE_BUNDLE",
-"created_at": TIMESTAMP,
+"created_at": __TIMESTAMP__,
 "parents": [],
 "body": {
 "release": {

--- a/backend/smoke-tests/releases/create-release-bundle-rftc.tmpl.json
+++ b/backend/smoke-tests/releases/create-release-bundle-rftc.tmpl.json
@@ -1,7 +1,7 @@
 {
 "v": 1,
 "type": "CREATE_RELEASE_BUNDLE",
-"created_at": "TIMESTAMP",
+"created_at": __TIMESTAMP__,
 "parents": [],
 "body": {
 "release": {

--- a/backend/smoke-tests/releases/create-release-bundle-rhythms-cosmic-sky.tmpl.json
+++ b/backend/smoke-tests/releases/create-release-bundle-rhythms-cosmic-sky.tmpl.json
@@ -1,7 +1,7 @@
 {
 "v": 1,
 "type": "CREATE_RELEASE_BUNDLE",
-"created_at": "TIMESTAMP",
+"created_at": __TIMESTAMP__,
 "parents": [],
 "body": {
 "release": {

--- a/backend/smoke-tests/releases/create-release-bundle-see-you-in-magic.tmpl.json
+++ b/backend/smoke-tests/releases/create-release-bundle-see-you-in-magic.tmpl.json
@@ -1,7 +1,7 @@
 {
 "v": 1,
 "type": "CREATE_RELEASE_BUNDLE",
-"created_at": TIMESTAMP,
+"created_at": __TIMESTAMP__,
 "parents": [],
 "body": {
 "release": {

--- a/backend/smoke-tests/releases/create-release-bundle-songs-about-angels.tmpl.json
+++ b/backend/smoke-tests/releases/create-release-bundle-songs-about-angels.tmpl.json
@@ -1,7 +1,7 @@
 {
 "v": 1,
 "type": "CREATE_RELEASE_BUNDLE",
-"created_at": "TIMESTAMP",
+"created_at": __TIMESTAMP__,
 "parents": [],
 "body": {
 "release": {

--- a/backend/smoke-tests/releases/create-release-bundle-ten-commandos.tmpl.json
+++ b/backend/smoke-tests/releases/create-release-bundle-ten-commandos.tmpl.json
@@ -1,7 +1,7 @@
 {
 "v": 1,
 "type": "CREATE_RELEASE_BUNDLE",
-"created_at": TIMESTAMP,
+"created_at": __TIMESTAMP__,
 "parents": [],
 "body": {
 "release": {

--- a/backend/smoke-tests/releases/create-release-bundle-under-river.tmpl.json
+++ b/backend/smoke-tests/releases/create-release-bundle-under-river.tmpl.json
@@ -1,7 +1,7 @@
 {
 "v": 1,
 "type": "CREATE_RELEASE_BUNDLE",
-"created_at": "TIMESTAMP",
+"created_at": __TIMESTAMP__,
 "parents": [],
 "body": {
 "release": {


### PR DESCRIPTION
Fixed all 21 smoke test bundles to use consistent __TIMESTAMP__ format.

Before:
- 10 files used `"TIMESTAMP"` (quoted string)
- 6 files used `TIMESTAMP` (unquoted, no underscores)
- 5 files already used `__TIMESTAMP__` (correct)

After:
- All 21 files now use `__TIMESTAMP__` (unquoted with double underscores)

This provides consistency while the loader remains robust enough to handle legacy formats if needed.
