### PR TITLE
Fix JSON syntax error in plosivs bundle

### DIFF
--- a/backend/smoke-tests/releases/create-release-bundle-plosivs.tmpl.json
+++ b/backend/smoke-tests/releases/create-release-bundle-plosivs.tmpl.json
@@ -12,7 +12,7 @@
 "format": "CD",
 "country": "US",
 "catalog_number": "SMOKE-TEST-023",
-"trivia": "Smoke-test release bundle based on Plosivs (Discogs) track listing and personnel. Reuses Smoke John Reis, Smoke Rob Crow, and Smoke Adam Willard person_ids from previous bundles. Sounds like the red version is the retail version and the black version is the "tour only" version. Apparently, there is a second LP's worth of material already near completion. This record was mostly tracked remotely."
+"trivia": "Smoke-test release bundle based on Plosivs (Discogs) track listing and personnel. Reuses Smoke John Reis, Smoke Rob Crow, and Smoke Adam Willard person_ids from previous bundles. Sounds like the red version is the retail version and the black version is the \"tour only\" version. Apparently, there is a second LP's worth of material already near completion. This record was mostly tracked remotely."
 },
 "labels": [
 {


### PR DESCRIPTION
Escape quotes in trivia field: "tour only" -> \"tour only\"

This was causing JSON parse error at line 15 column 271.

https://claude.ai/code/session_0187oWeWfVN1qudCvpeDhsHx