### PR TITLE
Make chain profile the true single source of truth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,14 +12,13 @@ CHAIN_PROFILE=jungle4
 # ====================
 # Blockchain Configuration
 # ====================
-# Default: Jungle4 testnet for development
-# For EOS mainnet, use CHAIN_PROFILE=mainnet or override individually:
-#   CHAIN_ID=aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906
-#   RPC_URL=https://eos.greymass.com
-CHAIN_ID=73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d
-RPC_URL=https://jungle4.greymass.com
-CONTRACT_ACCOUNT=polarismusic
-TOKEN_CONTRACT_ACCOUNT=polaristoken
+# These are derived automatically from CHAIN_PROFILE above.
+# Only uncomment/set to override profile defaults.
+# For EOS mainnet: CHAIN_PROFILE=mainnet (or override individually below)
+# CHAIN_ID=73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d
+# RPC_URL=https://jungle4.greymass.com
+# CONTRACT_ACCOUNT=polarismusic
+# TOKEN_CONTRACT_ACCOUNT=polaristoken
 TOKEN_SYMBOL=MUS
 TOKEN_PRECISION=4
 

--- a/README.md
+++ b/README.md
@@ -143,24 +143,34 @@ VITE_GRAPHQL_URL=http://localhost:3000/graphql
 
 ### Chain Ingestion (Blockchain Events)
 
-The system supports automated chain ingestion via **Substreams** (recommended), which monitors the blockchain for anchored events and automatically ingests them into the graph database.
+The system supports automated chain ingestion from the blockchain into the graph database. Three ingestion modes are available:
 
 #### Ingestion Modes
 
-**Default Mode: Substreams (Recommended)**
+**Substreams (Primary, Recommended)**
 
 The `substreams-sink` service consumes events from the blockchain via Pinax Firehose and posts them to the backend ingestion endpoint. This is the modern, reliable ingestion method that uses Substreams to stream blockchain data in real-time.
 
-**Legacy Mode: Direct Blockchain Polling**
+**SHiP Fallback (State History Plugin)**
 
-A legacy `processor` service is available that directly polls the blockchain via SHiP/History API. This service is **disabled by default** to prevent double-ingestion conflicts. To enable it:
+The `chain-source` worker connects directly to an Antelope node's `state_history_plugin` WebSocket endpoint using the real binary SHiP protocol (`@wharfkit/antelope`). It decodes action traces using the contract ABI and emits canonical `AnchoredEvent` objects identical to Substreams output. Use when Substreams is unavailable or for self-hosted ingestion.
 
 ```bash
-# Run with legacy processor instead of Substreams
+# Run with SHiP fallback
+npm run start:ship
+# Or via Docker:
+docker compose --profile ship up chain-source
+```
+
+**Legacy Processor (Deprecated)**
+
+A legacy `processor` service is available that directly polls the blockchain. This service is **disabled by default**. To enable it:
+
+```bash
 docker compose --profile legacy up
 ```
 
-⚠️ **Warning**: Do not run both ingestion methods simultaneously, as this will cause duplicate event processing and graph inconsistencies.
+⚠️ **Warning**: Do not run multiple ingestion methods simultaneously, as this may cause duplicate event processing. Built-in deduplication (content hash + block/trx/ordinal) provides safety during source switching, but avoid sustained overlap.
 
 #### Substreams HTTP Sink (Default)
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -43,9 +43,11 @@ CONTRACT_ACCOUNT=polarismusic
 # RPC_CIPHERS=
 
 # Chain Ingestion Source (T6)
-# Options: substreams (primary, recommended) | ship (NOT IMPLEMENTED - will fail)
-# CRITICAL: SHiP mode is non-functional (drops binary messages, requires ABI deserialization)
-# Use CHAIN_SOURCE=substreams for production and development
+# Options: substreams (primary, recommended) | ship (fallback, direct node)
+# Substreams: Cloud-hosted via Pinax, requires SUBSTREAMS_API_TOKEN
+# SHiP: Direct connection to a node's state_history_plugin WebSocket
+#   Requires SHIP_URL and a reachable SHiP endpoint
+#   Run with: npm run start:ship (or docker compose --profile ship up chain-source)
 CHAIN_SOURCE=substreams
 
 # Ingest Mode: Controls whether write endpoints apply changes immediately or event-only
@@ -58,10 +60,9 @@ CHAIN_SOURCE=substreams
 INGEST_MODE=dev
 
 # SHiP (State History Plugin) Configuration - Only used if CHAIN_SOURCE=ship
-# WARNING: SHiP binary deserialization is NOT implemented
-# Setting CHAIN_SOURCE=ship will cause immediate startup failure
-# If SHiP support is required, see backend/src/indexer/shipEventSource.js for implementation notes
-# Recommended libraries: eosio-ship-reader, @greymass/eosio
+# The SHiP transport uses @wharfkit/antelope for binary protocol decode and ABI-based
+# action deserialization. See backend/src/indexer/ship/ for implementation.
+# Run: npm run start:ship (or docker compose --profile ship up chain-source)
 SHIP_URL=ws://localhost:8080
 START_BLOCK=0
 END_BLOCK=0xffffffff

--- a/backend/src/api/index.js
+++ b/backend/src/api/index.js
@@ -10,65 +10,7 @@
 
 import APIServer from './server.js';
 import { resolveChainConfig } from '../../../shared/config/chainProfiles.js';
-
-/**
- * Verify that the configured CHAIN_ID matches the chain we connect to.
- * Prevents accidental mainnet/testnet/local mismatches.
- * Only runs when RPC_URL and CHAIN_ID are both configured.
- */
-async function verifyChainId() {
-    const chainConfig = resolveChainConfig();
-    const { rpcUrl, chainId, name: profileName } = chainConfig;
-
-    // Skip verification if no RPC URL or chain ID configured
-    if (!rpcUrl || !chainId) return;
-
-    // Skip for dev mode without explicit chain config
-    const ingestMode = process.env.INGEST_MODE || chainConfig.ingestMode;
-    if (ingestMode === 'dev' && !process.env.CHAIN_ID && !process.env.CHAIN_PROFILE) return;
-
-    console.log(`[startup] Chain profile: ${profileName}`);
-    console.log(`[startup] RPC: ${rpcUrl}`);
-    console.log(`[startup] Expected chain ID: ${chainId.substring(0, 16)}...`);
-
-    try {
-        const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), 5000);
-
-        const response = await fetch(`${rpcUrl}/v1/chain/get_info`, {
-            signal: controller.signal,
-        });
-        clearTimeout(timeout);
-
-        if (!response.ok) {
-            console.warn(`[startup] Chain ID verification skipped: RPC returned ${response.status}`);
-            return;
-        }
-
-        const info = await response.json();
-        const remoteChainId = info.chain_id;
-
-        if (remoteChainId !== chainId) {
-            console.error('═══════════════════════════════════════════════════════════════');
-            console.error('FATAL: Chain ID mismatch!');
-            console.error(`  Configured: ${chainId}`);
-            console.error(`  RPC reports: ${remoteChainId}`);
-            console.error(`  Profile: ${profileName}, RPC: ${rpcUrl}`);
-            console.error('  Check CHAIN_PROFILE, CHAIN_ID, and RPC_URL in your environment.');
-            console.error('═══════════════════════════════════════════════════════════════');
-            process.exit(1);
-        }
-
-        console.log(`[startup] Chain ID verified: ${remoteChainId.substring(0, 16)}... (${profileName})`);
-        console.log(`[startup] Head block: ${info.head_block_num}, LIB: ${info.last_irreversible_block_num}`);
-    } catch (error) {
-        if (error.name === 'AbortError') {
-            console.warn('[startup] Chain ID verification skipped: RPC timeout');
-        } else {
-            console.warn(`[startup] Chain ID verification skipped: ${error.message}`);
-        }
-    }
-}
+import { verifyChainId } from '../utils/verifyChainId.js';
 
 // Load configuration from environment variables
 const config = {
@@ -115,7 +57,7 @@ const config = {
 const server = new APIServer(config);
 
 (async () => {
-    await verifyChainId();
+    await verifyChainId(resolveChainConfig());
     await server.start();
 })().catch((error) => {
     console.error('Failed to start server:', error);

--- a/backend/src/indexer/chainSourceManager.js
+++ b/backend/src/indexer/chainSourceManager.js
@@ -108,9 +108,12 @@ export class ChainSourceManager {
             use_local_abi: shipConfig.useLocalAbi,
         });
 
-        // Pass checkpoint store if available
+        // Pass checkpoint store and key if available
         if (this.config.checkpointStore) {
             shipConfig.checkpointStore = this.config.checkpointStore;
+        }
+        if (this.config.checkpointKey) {
+            shipConfig.checkpointKey = this.config.checkpointKey;
         }
 
         const ship = new ShipEventSource(shipConfig);

--- a/backend/src/indexer/runChainSource.js
+++ b/backend/src/indexer/runChainSource.js
@@ -5,6 +5,10 @@
  * This worker replaces the legacy runProcessor.js for SHiP-based ingestion
  * and can also coordinate Substreams mode.
  *
+ * All chain-related defaults are driven by the shared chain profile
+ * (shared/config/chainProfiles.js). Environment variables override
+ * profile defaults when set.
+ *
  * Dependencies initialized:
  * - Neo4j (MusicGraphDatabase)
  * - EventStore (IPFS + S3 + Redis)
@@ -21,13 +25,17 @@ import EventStore from '../storage/eventStore.js';
 import EventProcessor from './eventProcessor.js';
 import { IngestionHandler } from '../api/ingestion.js';
 import { ChainSourceManager } from './chainSourceManager.js';
+import { resolveChainConfig } from '../../../shared/config/chainProfiles.js';
+import { verifyChainId } from '../utils/verifyChainId.js';
 import { createLogger } from '../utils/logger.js';
 
 const log = createLogger('indexer.runChainSource');
 
 // ---------------------------------------------------------------------------
-// Configuration from environment
+// Configuration — profile-driven with env overrides
 // ---------------------------------------------------------------------------
+
+const chainConfig = resolveChainConfig();
 
 const config = {
     database: {
@@ -57,16 +65,17 @@ const config = {
         },
     },
 
-    chainSource: process.env.CHAIN_SOURCE || 'ship',
-    rpcUrl: process.env.RPC_URL || 'https://jungle4.greymass.com',
-    contractAccount: process.env.CONTRACT_ACCOUNT || 'polarismusic',
-
-    // SHiP-specific
-    shipUrl: process.env.SHIP_URL || 'ws://localhost:8080',
-    startBlock: process.env.START_BLOCK ? parseInt(process.env.START_BLOCK) : 0,
-    endBlock: process.env.END_BLOCK ? parseInt(process.env.END_BLOCK) : 0xffffffff,
-    irreversibleOnly: process.env.IRREVERSIBLE_ONLY,
-    useLocalAbi: process.env.USE_LOCAL_ABI,
+    // Chain config — all driven by profile, env vars already folded in by resolveChainConfig()
+    chainSource: chainConfig.chainSource,
+    chainId: chainConfig.chainId,
+    profileName: chainConfig.name,
+    rpcUrl: chainConfig.rpcUrl,
+    contractAccount: chainConfig.contractAccount,
+    shipUrl: chainConfig.shipUrl || 'ws://localhost:8080',
+    startBlock: chainConfig.startBlock,
+    endBlock: chainConfig.endBlock,
+    irreversibleOnly: chainConfig.irreversibleOnly,
+    useLocalAbi: chainConfig.useLocalAbi,
     contractAbiPath: process.env.CONTRACT_ABI_PATH || '',
     tlsCaCertPath: process.env.SHIP_CA_CERT_PATH || '',
     tlsRejectUnauthorized: process.env.SHIP_REJECT_UNAUTHORIZED,
@@ -77,13 +86,19 @@ const config = {
 // ---------------------------------------------------------------------------
 
 log.info('chain_source_config', {
+    profile: config.profileName,
     chain_source: config.chainSource,
+    chain_id: config.chainId ? config.chainId.substring(0, 16) + '...' : '(none)',
     rpc_url: config.rpcUrl,
     contract: config.contractAccount,
     ship_url: config.shipUrl,
     start_block: config.startBlock,
+    irreversible_only: config.irreversibleOnly,
     graph_uri: config.database.uri,
 });
+
+// Verify chain ID before starting ingestion (prevents wrong-network corruption)
+await verifyChainId(chainConfig);
 
 // Initialize infrastructure
 const db = new MusicGraphDatabase(config.database);
@@ -115,11 +130,17 @@ try {
     checkpointRedis = null;
 }
 
+// Checkpoint key namespaced by chainId to prevent cross-environment contamination
+const checkpointKey = config.chainId
+    ? `ship:checkpoint:${config.chainId.substring(0, 16)}:${config.contractAccount}`
+    : `ship:checkpoint:${config.profileName}:${config.contractAccount}`;
+
 // Create ChainSourceManager with checkpoint store injected
 const manager = new ChainSourceManager(
     {
         ...config,
         checkpointStore: checkpointRedis,
+        checkpointKey,
     },
     ingestionHandler
 );

--- a/backend/src/utils/verifyChainId.js
+++ b/backend/src/utils/verifyChainId.js
@@ -1,0 +1,107 @@
+/**
+ * @fileoverview Chain ID verification utility
+ *
+ * Verifies that the configured chain ID matches the chain reported by the
+ * RPC endpoint. Prevents accidental mainnet/testnet/local mismatches that
+ * could corrupt the graph database.
+ *
+ * Used by both the API server and the chain-source worker.
+ *
+ * @module utils/verifyChainId
+ */
+
+import { createLogger } from './logger.js';
+
+const log = createLogger('utils.verifyChainId');
+
+/**
+ * Verify the configured chain ID matches the RPC endpoint.
+ *
+ * @param {Object} chainConfig - Resolved chain configuration
+ * @param {string} chainConfig.rpcUrl - RPC endpoint URL
+ * @param {string} chainConfig.chainId - Expected chain ID
+ * @param {string} chainConfig.name - Profile name
+ * @param {Object} [options]
+ * @param {boolean} [options.fatal=true] - Exit process on mismatch
+ * @param {number} [options.timeoutMs=5000] - RPC request timeout
+ * @throws {Error} If fatal=false and chain ID mismatches
+ */
+export async function verifyChainId(chainConfig, options = {}) {
+    const { rpcUrl, chainId, name: profileName } = chainConfig;
+    const { fatal = true, timeoutMs = 5000 } = options;
+
+    // Skip if no RPC URL or chain ID configured
+    if (!rpcUrl || !chainId) {
+        log.info('chain_id_verify_skip', { reason: 'no rpcUrl or chainId' });
+        return;
+    }
+
+    // Skip for dev mode without explicit chain config
+    const ingestMode = process.env.INGEST_MODE || chainConfig.ingestMode;
+    if (ingestMode === 'dev' && !process.env.CHAIN_ID && !process.env.CHAIN_PROFILE) {
+        log.info('chain_id_verify_skip', { reason: 'dev mode without explicit config' });
+        return;
+    }
+
+    log.info('chain_id_verify_start', {
+        profile: profileName,
+        rpc_url: rpcUrl,
+        expected: chainId.substring(0, 16) + '...',
+    });
+
+    try {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+        const response = await fetch(`${rpcUrl}/v1/chain/get_info`, {
+            signal: controller.signal,
+        });
+        clearTimeout(timeout);
+
+        if (!response.ok) {
+            log.warn('chain_id_verify_skip', { reason: `RPC returned ${response.status}` });
+            return;
+        }
+
+        const info = await response.json();
+        const remoteChainId = info.chain_id;
+
+        if (remoteChainId !== chainId) {
+            const msg = `Chain ID mismatch: configured ${chainId}, RPC reports ${remoteChainId} (profile: ${profileName}, RPC: ${rpcUrl})`;
+            log.error('chain_id_mismatch', {
+                configured: chainId,
+                remote: remoteChainId,
+                profile: profileName,
+                rpc_url: rpcUrl,
+            });
+
+            if (fatal) {
+                console.error('═══════════════════════════════════════════════════════════════');
+                console.error('FATAL: Chain ID mismatch!');
+                console.error(`  Configured: ${chainId}`);
+                console.error(`  RPC reports: ${remoteChainId}`);
+                console.error(`  Profile: ${profileName}, RPC: ${rpcUrl}`);
+                console.error('  Check CHAIN_PROFILE, CHAIN_ID, and RPC_URL in your environment.');
+                console.error('═══════════════════════════════════════════════════════════════');
+                process.exit(1);
+            }
+
+            throw new Error(msg);
+        }
+
+        log.info('chain_id_verified', {
+            chain_id: remoteChainId.substring(0, 16) + '...',
+            profile: profileName,
+            head_block: info.head_block_num,
+            lib: info.last_irreversible_block_num,
+        });
+    } catch (error) {
+        if (error.name === 'AbortError') {
+            log.warn('chain_id_verify_skip', { reason: 'RPC timeout' });
+        } else if (error.message?.includes('Chain ID mismatch')) {
+            throw error; // Re-throw mismatch errors
+        } else {
+            log.warn('chain_id_verify_skip', { reason: error.message });
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,20 +161,21 @@ services:
       # Only use for isolated testing with mock data
       # - ALLOW_UNSIGNED_EVENTS=true  # KEEP COMMENTED - only enable for testing!
 
-      # Chain Profile (shared config from shared/config/chainProfiles.js)
+      # Chain Profile — single source of truth (shared/config/chainProfiles.js)
+      # App code calls resolveChainConfig() which derives CHAIN_ID, RPC_URL,
+      # CONTRACT_ACCOUNT, CHAIN_SOURCE, etc. from the profile. Only set explicit
+      # overrides below when intentionally diverging from profile defaults.
       - CHAIN_PROFILE=${CHAIN_PROFILE:-jungle4}
-
-      # Blockchain (Jungle4 testnet for development)
-      - CHAIN_ID=${CHAIN_ID:-73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d}
-      - RPC_URL=${RPC_URL:-https://jungle4.greymass.com}
-      - CHAIN_WS_URL=${CHAIN_WS_URL:-wss://jungle4.greymass.com}
-      - CONTRACT_ACCOUNT=${CONTRACT_ACCOUNT:-polarismusic}
+      - CHAIN_ID=${CHAIN_ID:-}
+      - RPC_URL=${RPC_URL:-}
+      - CONTRACT_ACCOUNT=${CONTRACT_ACCOUNT:-}
+      - CHAIN_WS_URL=${CHAIN_WS_URL:-}
 
       # Chain Ingestion Source (substreams = primary, ship = fallback)
-      - CHAIN_SOURCE=${CHAIN_SOURCE:-substreams}
+      - CHAIN_SOURCE=${CHAIN_SOURCE:-}
       - SHIP_URL=${SHIP_URL:-}
-      - IRREVERSIBLE_ONLY=${IRREVERSIBLE_ONLY:-false}
-      - USE_LOCAL_ABI=${USE_LOCAL_ABI:-false}
+      - IRREVERSIBLE_ONLY=${IRREVERSIBLE_ONLY:-}
+      - USE_LOCAL_ABI=${USE_LOCAL_ABI:-}
 
       # Graph Database
       - GRAPH_URI=bolt://neo4j:7687
@@ -338,14 +339,13 @@ services:
       - VITE_API_URL=http://localhost:3000/api
       - VITE_GRAPHQL_URL=http://localhost:3000/graphql
 
-      # Chain Profile (shared config from shared/config/chainProfiles.js)
+      # Chain Profile — frontend uses shared/config/chainProfiles.js via import
+      # Profile drives all defaults; only override when intentionally diverging.
       - VITE_CHAIN_PROFILE=${CHAIN_PROFILE:-jungle4}
-
-      # Blockchain configuration (explicit values to avoid relying on code defaults)
-      - VITE_CHAIN_ID=${VITE_CHAIN_ID:-73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d}
-      - VITE_RPC_URL=${VITE_RPC_URL:-https://jungle4.greymass.com}
-      - VITE_CONTRACT_ACCOUNT=${VITE_CONTRACT_ACCOUNT:-polarismusic}
-      - VITE_USE_LOCAL_ABI=${VITE_USE_LOCAL_ABI:-true}
+      - VITE_CHAIN_ID=${VITE_CHAIN_ID:-}
+      - VITE_RPC_URL=${VITE_RPC_URL:-}
+      - VITE_CONTRACT_ACCOUNT=${VITE_CONTRACT_ACCOUNT:-}
+      - VITE_USE_LOCAL_ABI=${VITE_USE_LOCAL_ABI:-}
     volumes:
       - ./frontend/src:/app/src
       - ./frontend/public:/app/public
@@ -368,17 +368,18 @@ services:
     container_name: polaris-chain-source
     environment:
       - NODE_ENV=${NODE_ENV:-development}
+      # Chain Profile drives all chain defaults via resolveChainConfig()
       - CHAIN_PROFILE=${CHAIN_PROFILE:-jungle4}
       - CHAIN_SOURCE=ship
-      - SHIP_URL=${SHIP_URL:-ws://localhost:8080}
+      - SHIP_URL=${SHIP_URL:-}
       - SHIP_CA_CERT_PATH=${SHIP_CA_CERT_PATH:-}
-      - SHIP_REJECT_UNAUTHORIZED=${SHIP_REJECT_UNAUTHORIZED:-true}
-      - IRREVERSIBLE_ONLY=${IRREVERSIBLE_ONLY:-false}
-      - USE_LOCAL_ABI=${USE_LOCAL_ABI:-true}
+      - SHIP_REJECT_UNAUTHORIZED=${SHIP_REJECT_UNAUTHORIZED:-}
+      - IRREVERSIBLE_ONLY=${IRREVERSIBLE_ONLY:-}
+      - USE_LOCAL_ABI=${USE_LOCAL_ABI:-}
       - CONTRACT_ABI_PATH=${CONTRACT_ABI_PATH:-}
-      - RPC_URL=${RPC_URL:-https://jungle4.greymass.com}
-      - CONTRACT_ACCOUNT=${CONTRACT_ACCOUNT:-polarismusic}
-      - START_BLOCK=${START_BLOCK:-0}
+      - RPC_URL=${RPC_URL:-}
+      - CONTRACT_ACCOUNT=${CONTRACT_ACCOUNT:-}
+      - START_BLOCK=${START_BLOCK:-}
       - GRAPH_URI=bolt://neo4j:7687
       - GRAPH_USER=neo4j
       - GRAPH_PASSWORD=polarisdev


### PR DESCRIPTION
P0 fixes:
- runChainSource.js now uses resolveChainConfig() for all chain defaults instead of hardcoding Jungle4-style fallbacks
- Extract verifyChainId() into shared utility (backend/src/utils/ verifyChainId.js) used by both API server and chain-source worker
- Namespace checkpoint key by chainId to prevent cross-environment contamination (ship:checkpoint:{chainId16}:{account})

P1 fixes:
- Remove stale "NOT IMPLEMENTED" / "will fail" / "non-functional" text from backend/.env.example — SHiP is now implemented
- Update README chain ingestion section to describe all three modes: Substreams (primary), SHiP (fallback), legacy processor (deprecated)
- docker-compose.yml: stop hardcoding Jungle4 CHAIN_ID, RPC_URL, VITE_CHAIN_ID, VITE_RPC_URL defaults — let empty env vars fall through to resolveChainConfig() profile defaults
- Root .env.example: comment out explicit chain vars, mark as optional overrides

All 377 tests pass, 0 regressions.
