### PR TITLE
chore: stage F — infra hygiene (compose secrets, action pinning, k8s …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,8 +42,14 @@ CHAIN_SOURCE=substreams
 # ====================
 # Graph Database (Neo4j)
 # ====================
+# NEO4J_PASSWORD is REQUIRED for docker-compose (uses ${VAR:?required} substitution).
+# It is the source of truth for both NEO4J_AUTH (neo4j/<password>) and the GRAPH_PASSWORD
+# the API/processor/chain-source services connect with.
+NEO4J_PASSWORD=polarisdev
 GRAPH_URI=bolt://localhost:7687
 GRAPH_USER=neo4j
+# GRAPH_PASSWORD is consumed by bare-metal backends (npm run dev). In docker-compose it
+# is overridden from NEO4J_PASSWORD above.
 GRAPH_PASSWORD=polarisdev
 
 # ====================
@@ -64,7 +70,14 @@ IPFS_URLS=http://localhost:5001
 # IPFS_URL=http://localhost:5001
 
 # S3 (MinIO for local dev)
+# MINIO_ROOT_USER / MINIO_ROOT_PASSWORD are REQUIRED for docker-compose (uses ${VAR:?required}).
+# In compose they double as S3_ACCESS_KEY / S3_SECRET_KEY for the api, processor, and
+# chain-source services so the credentials don't drift.
+MINIO_ROOT_USER=polaris
+MINIO_ROOT_PASSWORD=polarisdev123
 S3_ENDPOINT=http://localhost:9000
+# S3_ACCESS_KEY / S3_SECRET_KEY are consumed by bare-metal backends. In docker-compose
+# they are overridden from MINIO_ROOT_USER / MINIO_ROOT_PASSWORD above.
 S3_ACCESS_KEY=polaris
 S3_SECRET_KEY=polarisdev123
 S3_BUCKET=polaris-events
@@ -73,6 +86,8 @@ S3_REGION=us-east-1
 # ====================
 # Redis Cache
 # ====================
+# REDIS_PASSWORD is REQUIRED for docker-compose (uses ${VAR:?required}). Used both as
+# the redis-server --requirepass and as the API/processor REDIS_PASSWORD.
 REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=polarisdev

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -48,10 +48,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -121,7 +121,7 @@ jobs:
         SKIP_GRAPH_TESTS: 'true'
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
       if: matrix.node-version == '20.x'
       with:
         file: ./backend/coverage/lcov.info
@@ -135,13 +135,13 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Build Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         context: ./backend
         file: ./backend/Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -40,7 +40,7 @@ jobs:
         if: matrix.node-version == '20.x'
 
       - name: Upload coverage reports
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         if: matrix.node-version == '20.x'
         with:
           files: ./backend/coverage/lcov.info
@@ -54,10 +54,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20.x'
           cache: 'npm'
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Verify Docker Compose config
         run: docker compose config > /dev/null
@@ -121,7 +121,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Verify contract syntax
         run: |

--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Install EOSIO CDT
       run: |
@@ -59,7 +59,7 @@ jobs:
         fi
 
     - name: Upload compiled artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: compiled-contracts
         path: |
@@ -78,10 +78,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -105,7 +105,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Run clang-tidy
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Install kubectl
-      uses: azure/setup-kubectl@v4
+      uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
       with:
         version: 'v1.28.0'
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,13 +34,13 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Log in to Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -48,7 +48,7 @@ jobs:
 
     - name: Extract metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.component }}
         tags: |
@@ -59,7 +59,7 @@ jobs:
           type=sha,prefix={{branch}}-
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         context: ${{ matrix.component == 'frontend' && '.' || format('./{0}', matrix.component) }}
         file: ./${{ matrix.component }}/Dockerfile
@@ -74,7 +74,7 @@ jobs:
           VERSION=${{ steps.meta.outputs.version }}
 
     - name: Generate SBOM
-      uses: anchore/sbom-action@v0
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
       with:
         # Use the exact tag produced by docker/metadata-action (already lowercased/valid)
         image: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
@@ -83,7 +83,7 @@ jobs:
 
 
     - name: Upload SBOM
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: sbom-${{ matrix.component }}
         path: sbom-${{ matrix.component }}.spdx.json
@@ -103,14 +103,14 @@ jobs:
 
     steps:
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@v0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
       with:
         image-ref: ghcr.io/polarismusic/polaris-music/${{ matrix.component }}:main
         format: 'sarif'
         output: 'trivy-results-${{ matrix.component }}.sarif'
 
     - name: Upload Trivy results to GitHub Security
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
       with:
         sarif_file: 'trivy-results-${{ matrix.component }}.sarif'
         category: ${{ matrix.component }}

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -66,13 +66,13 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Build Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         context: .
         file: ./frontend/Dockerfile

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,8 +14,8 @@ jobs:
       contracts: ${{ steps.filter.outputs.contracts }}
       k8s: ${{ steps.filter.outputs.k8s }}
     steps:
-    - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
       id: filter
       with:
         filters: |
@@ -35,10 +35,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: '20.x'
 
@@ -64,10 +64,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Run Semgrep
-      uses: returntocorp/semgrep-action@v1
+      uses: returntocorp/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1
       continue-on-error: true
       with:
         config: >-
@@ -77,7 +77,7 @@ jobs:
           p/typescript
 
     - name: Dependency Review
-      uses: actions/dependency-review-action@v4
+      uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
       continue-on-error: true
       with:
         fail-on-severity: moderate
@@ -90,7 +90,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Install kustomize
       run: |
@@ -125,7 +125,7 @@ jobs:
 
     steps:
     - name: Add component labels
-      uses: actions/labeler@v5
+      uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         configuration-path: .github/labeler.yml
@@ -137,7 +137,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: codelytv/pr-size-labeler@v1
+    - uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # v1
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         xs_label: 'size/xs'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
 
@@ -36,7 +36,7 @@ jobs:
         echo "$CHANGELOG" > changelog.txt
 
     - name: Create Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
       with:
         body_path: changelog.txt
         draft: false
@@ -54,7 +54,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Install EOSIO CDT
       run: |
@@ -75,7 +75,7 @@ jobs:
           polaris.music.cpp
 
     - name: Upload to release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
       with:
         files: contracts/polaris-contracts-${{ github.ref_name }}.tar.gz
       env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "7474:7474"  # HTTP
       - "7687:7687"  # Bolt
     environment:
-      - NEO4J_AUTH=neo4j/polarisdev
+      - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:?NEO4J_PASSWORD is required (see .env.example)}
       - NEO4J_PLUGINS=["apoc", "graph-data-science"]
       - NEO4J_dbms_security_procedures_unrestricted=apoc.*,gds.*
       - NEO4J_dbms_memory_heap_initial__size=512m
@@ -21,7 +21,7 @@ services:
     networks:
       - polaris-network
     healthcheck:
-      test: ["CMD-SHELL", "cypher-shell -u neo4j -p polarisdev 'RETURN 1' >/dev/null 2>&1 || exit 1"]
+      test: ["CMD-SHELL", "cypher-shell -u neo4j -p \"${NEO4J_PASSWORD:?NEO4J_PASSWORD is required (see .env.example)}\" 'RETURN 1' >/dev/null 2>&1 || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 30
@@ -33,13 +33,13 @@ services:
     container_name: polaris-redis
     ports:
       - "6379:6379"
-    command: redis-server --requirepass polarisdev --maxmemory 256mb --maxmemory-policy allkeys-lru
+    command: redis-server --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD is required (see .env.example)} --maxmemory 256mb --maxmemory-policy allkeys-lru
     volumes:
       - redis-data:/data
     networks:
       - polaris-network
     healthcheck:
-      test: ["CMD", "redis-cli", "-a", "polarisdev", "ping"]
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:?REDIS_PASSWORD is required (see .env.example)}", "ping"]
       interval: 10s
       timeout: 3s
       retries: 5
@@ -99,8 +99,8 @@ services:
       - "9000:9000"     # API
       - "9001:9001"     # Console
     environment:
-      - MINIO_ROOT_USER=polaris
-      - MINIO_ROOT_PASSWORD=polarisdev123
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER:?MINIO_ROOT_USER is required (see .env.example)}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required (see .env.example)}
       - MINIO_BROWSER_REDIRECT_URL=http://localhost:9001
     command: server /data --console-address ":9001"
     volumes:
@@ -132,10 +132,13 @@ services:
     depends_on:
       minio-health:
         condition: service_healthy
+    environment:
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER:?MINIO_ROOT_USER is required (see .env.example)}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required (see .env.example)}
     entrypoint: >
       /bin/sh -c "
       set -e;
-      /usr/bin/mc alias set polaris http://minio:9000 polaris polarisdev123;
+      /usr/bin/mc alias set polaris http://minio:9000 \"$$MINIO_ROOT_USER\" \"$$MINIO_ROOT_PASSWORD\";
       /usr/bin/mc mb -p polaris/polaris-events || true;
       /usr/bin/mc anonymous set download polaris/polaris-events;
       echo 'MinIO init complete';
@@ -180,7 +183,7 @@ services:
       # Graph Database
       - GRAPH_URI=bolt://neo4j:7687
       - GRAPH_USER=neo4j
-      - GRAPH_PASSWORD=polarisdev
+      - GRAPH_PASSWORD=${NEO4J_PASSWORD:?NEO4J_PASSWORD is required (see .env.example)}
 
       # Storage (IPFS)
       # Multi-node for redundancy (primary + secondary)
@@ -188,15 +191,15 @@ services:
       - IPFS_URLS=http://ipfs:5001,http://ipfs2:5001
       - IPFS_URL=http://ipfs:5001  # Legacy fallback (single-node)
       - S3_ENDPOINT=http://minio:9000
-      - S3_ACCESS_KEY=polaris
-      - S3_SECRET_KEY=polarisdev123
+      - S3_ACCESS_KEY=${MINIO_ROOT_USER:?MINIO_ROOT_USER is required (see .env.example)}
+      - S3_SECRET_KEY=${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required (see .env.example)}
       - S3_BUCKET=polaris-events
       - S3_REGION=us-east-1
 
       # Redis Cache
       - REDIS_HOST=redis
       - REDIS_PORT=6379
-      - REDIS_PASSWORD=polarisdev
+      - REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD is required (see .env.example)}
 
       # External Pinning Provider (optional, best-effort)
       - PIN_PROVIDER=${PIN_PROVIDER:-none}
@@ -268,7 +271,7 @@ services:
       # Graph Database
       - GRAPH_URI=bolt://neo4j:7687
       - GRAPH_USER=neo4j
-      - GRAPH_PASSWORD=polarisdev
+      - GRAPH_PASSWORD=${NEO4J_PASSWORD:?NEO4J_PASSWORD is required (see .env.example)}
 
       # Storage (IPFS)
       # Multi-node for redundancy (primary + secondary)
@@ -276,15 +279,15 @@ services:
       - IPFS_URLS=http://ipfs:5001,http://ipfs2:5001
       - IPFS_URL=http://ipfs:5001  # Legacy fallback (single-node)
       - S3_ENDPOINT=http://minio:9000
-      - S3_ACCESS_KEY=polaris
-      - S3_SECRET_KEY=polarisdev123
+      - S3_ACCESS_KEY=${MINIO_ROOT_USER:?MINIO_ROOT_USER is required (see .env.example)}
+      - S3_SECRET_KEY=${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required (see .env.example)}
       - S3_BUCKET=polaris-events
       - S3_REGION=us-east-1
 
       # Redis Cache
       - REDIS_HOST=redis
       - REDIS_PORT=6379
-      - REDIS_PASSWORD=polarisdev
+      - REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD is required (see .env.example)}
 
       # External Pinning Provider (optional, best-effort)
       - PIN_PROVIDER=${PIN_PROVIDER:-none}
@@ -382,17 +385,17 @@ services:
       - START_BLOCK=${START_BLOCK:-}
       - GRAPH_URI=bolt://neo4j:7687
       - GRAPH_USER=neo4j
-      - GRAPH_PASSWORD=polarisdev
+      - GRAPH_PASSWORD=${NEO4J_PASSWORD:?NEO4J_PASSWORD is required (see .env.example)}
       - IPFS_URLS=http://ipfs:5001,http://ipfs2:5001
       - IPFS_URL=http://ipfs:5001
       - S3_ENDPOINT=http://minio:9000
-      - S3_ACCESS_KEY=polaris
-      - S3_SECRET_KEY=polarisdev123
+      - S3_ACCESS_KEY=${MINIO_ROOT_USER:?MINIO_ROOT_USER is required (see .env.example)}
+      - S3_SECRET_KEY=${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required (see .env.example)}
       - S3_BUCKET=polaris-events
       - S3_REGION=us-east-1
       - REDIS_HOST=redis
       - REDIS_PORT=6379
-      - REDIS_PASSWORD=polarisdev
+      - REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD is required (see .env.example)}
       - REQUIRE_ACCOUNT_AUTH=${REQUIRE_ACCOUNT_AUTH:-true}
       - DEV_SIGNER_PRIVATE_KEY=${DEV_SIGNER_PRIVATE_KEY:-5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3}
       - LOG_LEVEL=debug

--- a/k8s/base/neo4j-statefulset.yaml
+++ b/k8s/base/neo4j-statefulset.yaml
@@ -48,6 +48,13 @@ spec:
             secretKeyRef:
               name: polaris-secrets
               key: NEO4J_AUTH
+        # NEO4J_PASSWORD is consumed by the liveness/readiness probes below.
+        # Sourced from the same secret as NEO4J_AUTH (the raw password, without the "neo4j/" prefix).
+        - name: NEO4J_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: polaris-secrets
+              key: GRAPH_PASSWORD
         - name: NEO4J_PLUGINS
           valueFrom:
             configMapKeyRef:
@@ -94,7 +101,7 @@ spec:
             command:
             - /bin/sh
             - -c
-            - cypher-shell -u neo4j -p $NEO4J_PASSWORD 'RETURN 1'
+            - cypher-shell -u neo4j -p "$NEO4J_PASSWORD" 'RETURN 1'
           initialDelaySeconds: 60
           periodSeconds: 30
           timeoutSeconds: 10
@@ -103,7 +110,7 @@ spec:
             command:
             - /bin/sh
             - -c
-            - cypher-shell -u neo4j -p $NEO4J_PASSWORD 'RETURN 1'
+            - cypher-shell -u neo4j -p "$NEO4J_PASSWORD" 'RETURN 1'
           initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 5


### PR DESCRIPTION
…probe env)

docker-compose.yml: replace every literal credential (NEO4J_AUTH/healthcheck, redis --requirepass + redis-cli, MinIO root user/password, minio-init alias, api/processor/chain-source GRAPH_PASSWORD/S3_ACCESS_KEY/S3_SECRET_KEY/REDIS_PASSWORD) with ${VAR:?required} so missing env fails fast instead of silently falling back to the dev default. MINIO_ROOT_USER/PASSWORD now drive S3_ACCESS_KEY/SECRET inside compose so the credentials cannot drift.

.env.example: document NEO4J_PASSWORD, MINIO_ROOT_USER, MINIO_ROOT_PASSWORD, REDIS_PASSWORD as required for compose; clarify that bare-metal backends still read GRAPH_PASSWORD / S3_ACCESS_KEY / S3_SECRET_KEY directly.

.github/workflows/*.yml: SHA-pin all 48 third-party uses: directives to a 40-char commit SHA with a trailing comment recording the version. Annotated tags dereferenced via `git ls-remote refs/tags/<tag>^{}`; lightweight tags use the ref SHA directly. actions/dependency-review-action has no v4 tag so points to the v4 branch head (== v4.9.0).

k8s/base/neo4j-statefulset.yaml: the liveness/readiness probes referenced $NEO4J_PASSWORD but no such env var was defined on the container, so the probes would have failed authentication. Add NEO4J_PASSWORD via secretKeyRef sourced from polaris-secrets.GRAPH_PASSWORD (the password without the "neo4j/" prefix), and quote the variable in the probe command so passwords with shell metachars work.

Verified: `docker compose config` parses cleanly with required vars set and contains zero polarisdev literals; kustomize/kubectl not available in this environment but every yaml file parses with `yaml.safe_load_all`.

https://claude.ai/code/session_019wN3i6YN5S91dHJY2wxTNz