### PR TITLE
chore: stage E — remove 'unsafe-eval' from visualization CSP

### DIFF
--- a/frontend/visualization.html
+++ b/frontend/visualization.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://localhost:3001 http://localhost:3000 https://eos.greymass.com https://jungle4.greymass.com https://eos.eosusa.io https://*.anchor.link wss://*.anchor.link https://cb.anchor.link wss://cb.anchor.link; img-src 'self' data: https:; media-src 'self' https: blob:; frame-src https://*.anchor.link;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://localhost:3001 http://localhost:3000 https://eos.greymass.com https://jungle4.greymass.com https://eos.eosusa.io https://*.anchor.link wss://*.anchor.link https://cb.anchor.link wss://cb.anchor.link; img-src 'self' data: https:; media-src 'self' https: blob:; frame-src https://*.anchor.link;">
     <link rel="icon" type="image/svg+xml" href="./favicon.svg">
     <title>Polaris Music Registry - Graph Visualization</title>
 


### PR DESCRIPTION
JIT (frontend/public/lib/jit.js, 18,540 lines, v2.0.1) does not require 'unsafe-eval'. Verified two ways:

  1. Static audit (zero matches in jit.js, frontend/src/, frontend/public/):
       eval(           new Function(   Function("...
       setTimeout("    setInterval("   .constructor("...
       document.write
     The single literal "eval" in jit.js is in a comment ("re-evaluating forces").

  2. Empirical browser test under strict CSP (script-src 'self' 'unsafe-inline', no 'unsafe-eval'): loaded jit.js into a fresh Chromium page, instantiated $jit.Hypertree with a 3-node graph, ran loadJSON + refresh + plot + fx.animate. Zero securitypolicyviolation events, zero console errors, zero pageerror events.

Removing 'unsafe-eval' from visualization.html closes R2 from the refactor plan. The directive was the only XSS-relevant relaxation in script-src; default-src 'self' and the rest of the policy are unchanged. End-to-end verification with the full app (search → group → info panel → like → edge navigation) still belongs to a manual smoke test, but the static + isolated-Hypertree evidence makes the regression risk minimal.

https://claude.ai/code/session_019wN3i6YN5S91dHJY2wxTNz