### PR TITLE
refactor(frontend): extract InfoPanelRenderer from MusicGraph (Stage J)

### DIFF
--- a/backend/test/visualization/musicGraphRenders.snapshot.test.js
+++ b/backend/test/visualization/musicGraphRenders.snapshot.test.js
@@ -3,24 +3,25 @@
  *
  * Stage H — Frontend render-method characterization snapshots.
  *
- * Locks the DOM output of the five `_render*` methods on MusicGraph so the
- * upcoming Stage J split (extract InfoPanelRenderer, FavoritesManager,
- * OverlayPositioner, GraphDataLoader from the ~2,562-line MusicGraph.js)
- * cannot silently change rendered HTML.
+ * Locks the DOM output of the five render methods that started life as
+ * `_render*` on MusicGraph (the ~2,562-line god class). Stage J extracted
+ * them into `frontend/src/visualization/InfoPanelRenderer.js`, where they
+ * are now public methods on the InfoPanelRenderer class — these snapshots
+ * are the regression net for that split.
  *
- * Strategy: source-extract + isolated invoke. The class itself is heavy to
- * instantiate (needs $jit, sibling module imports, real DOM containers).
- * Each render method is a leaf that only touches `this._escapeHtml`,
- * `this._detailField`, and a few stub-able navigation handlers. We:
+ * Strategy: source-extract + isolated invoke. The renderer class is light
+ * (no `$jit`, no live DOM container) but the source-extract approach is
+ * preserved so we re-read the live module on every run; any drift in a
+ * method body surfaces as a snapshot diff.
  *
- *   1. Read frontend/src/visualization/MusicGraph.js as text.
- *   2. Slice out each method body by name + brace-balancing.
+ *   1. Read frontend/src/visualization/InfoPanelRenderer.js as text.
+ *   2. Locate each method node via @babel/parser and slice its source.
  *   3. Compile the slice as a standalone function via `new Function(...)`.
  *   4. Invoke with `Function.prototype.call(stubThis, ...)` under jsdom.
  *   5. Snapshot the resulting outerHTML / innerHTML.
  *
- * This re-reads the live source every run, so any drift in the method body
- * surfaces as a snapshot diff (the alarm Stage J needs).
+ * Snapshot file is intentionally unchanged from Stage H — the HTML the
+ * renderer emits must be byte-identical after the move.
  */
 
 import { jest } from '@jest/globals';
@@ -31,8 +32,8 @@ import { parse } from '@babel/parser';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const MUSIC_GRAPH_PATH = resolve(__dirname, '../../../frontend/src/visualization/MusicGraph.js');
-const SOURCE = readFileSync(MUSIC_GRAPH_PATH, 'utf8');
+const RENDERER_PATH = resolve(__dirname, '../../../frontend/src/visualization/InfoPanelRenderer.js');
+const SOURCE = readFileSync(RENDERER_PATH, 'utf8');
 
 // ---------------------------------------------------------------------------
 // AST-based method extraction. Parses MusicGraph.js once, then locates each
@@ -65,7 +66,7 @@ const METHOD_INDEX = (() => {
 function extractMethod(methodName) {
     const node = METHOD_INDEX.get(methodName);
     if (!node) {
-        throw new Error(`extractMethod: ${methodName} not found in MusicGraph.js`);
+        throw new Error(`extractMethod: ${methodName} not found in InfoPanelRenderer.js`);
     }
     const params = node.params.map(p => SOURCE.slice(p.start, p.end)).join(', ');
     // Body is everything between the outer braces (exclusive).
@@ -94,17 +95,23 @@ function makeStubThis() {
         return `<div class="curate-field"><span class="curate-field-label">${escapeImpl(label)}</span><span class="curate-field-value">${escapeImpl(String(value))}</span></div>`;
     };
     const stub = {
-        _escapeHtml: escapeImpl,
-        _detailField: detailFieldImpl,
-        _attachNavLinkListeners: jest.fn(),
-        _navigateToRelease: jest.fn(),
-        _selectCurateOperation: jest.fn(),
-        _curateVoteFromDetail: jest.fn(),
+        // Helpers — now public methods on InfoPanelRenderer.
+        escapeHtml: escapeImpl,
+        detailField: detailFieldImpl,
+        // Nav/vote handlers were `this._foo` on MusicGraph; in the renderer
+        // they live behind a `callbacks` indirection so the module has no
+        // implicit coupling to MusicGraph beyond this object.
+        callbacks: {
+            attachNavLinkListeners: jest.fn(),
+            navigateToRelease: jest.fn(),
+            selectCurateOperation: jest.fn(),
+            voteFromDetail: jest.fn(),
+        },
     };
-    // The two delegating methods need real impls so _renderCurateDetail can
+    // The two delegating methods need real impls so renderCurateDetail can
     // invoke them through `this`.
-    stub._renderReleaseBundleDetail = compileMethod('_renderReleaseBundleDetail').bind(stub);
-    stub._renderClaimDetail = compileMethod('_renderClaimDetail').bind(stub);
+    stub.renderReleaseBundleDetail = compileMethod('renderReleaseBundleDetail').bind(stub);
+    stub.renderClaimDetail = compileMethod('renderClaimDetail').bind(stub);
     return stub;
 }
 
@@ -135,15 +142,14 @@ afterAll(() => {
 // If MusicGraph.js renames or removes any of these, the test should scream.
 // ---------------------------------------------------------------------------
 
-describe('Stage H · MusicGraph render methods · drift guard', () => {
+describe('Stage H · InfoPanelRenderer methods · drift guard', () => {
     test.each([
-        ['_renderSongDetails',         '(song, titleElement, contentElement)'],
-        ['_renderCurateRow',           '(op)'],
-        ['_renderCurateDetail',        '(container, resp, op)'],
-        ['_renderReleaseBundleDetail', '(container, detail)'],
-        ['_renderClaimDetail',         '(container, detail)'],
+        ['renderSongDetails',         '(song, titleElement, contentElement)'],
+        ['renderCurateRow',           '(op)'],
+        ['renderCurateDetail',        '(container, resp, op)'],
+        ['renderReleaseBundleDetail', '(container, detail)'],
+        ['renderClaimDetail',         '(container, detail)'],
     ])('method %s exists with signature %s', (name, sig) => {
-        // .replace strips type annotations / default values for simple equality
         const expected = sig.slice(1, -1).split(',').map(s => s.trim()).filter(Boolean).join(', ');
         const { params } = extractMethod(name);
         const actual = params.split(',').map(s => s.trim()).filter(Boolean).join(', ');
@@ -157,7 +163,7 @@ describe('Stage H · MusicGraph render methods · drift guard', () => {
 
 describe('Stage H · _renderSongDetails', () => {
     test('full song with writers, lyrics, and releases', () => {
-        const fn = compileMethod('_renderSongDetails');
+        const fn = compileMethod('renderSongDetails');
         const stub = makeStubThis();
 
         const titleEl = document.createElement('h2');
@@ -179,12 +185,12 @@ describe('Stage H · _renderSongDetails', () => {
 
         expect(titleEl.textContent).toBe('Come Together');
         expect(contentEl.innerHTML).toMatchSnapshot('full');
-        expect(stub._attachNavLinkListeners).toHaveBeenCalledTimes(1);
-        expect(stub._attachNavLinkListeners).toHaveBeenCalledWith(contentEl);
+        expect(stub.callbacks.attachNavLinkListeners).toHaveBeenCalledTimes(1);
+        expect(stub.callbacks.attachNavLinkListeners).toHaveBeenCalledWith(contentEl);
     });
 
     test('minimal song (no writers, no lyrics, no releases)', () => {
-        const fn = compileMethod('_renderSongDetails');
+        const fn = compileMethod('renderSongDetails');
         const stub = makeStubThis();
 
         const titleEl = document.createElement('h2');
@@ -202,7 +208,7 @@ describe('Stage H · _renderSongDetails', () => {
 
 describe('Stage H · _renderCurateRow', () => {
     test('open release row with positive net score', () => {
-        const fn = compileMethod('_renderCurateRow');
+        const fn = compileMethod('renderCurateRow');
         const stub = makeStubThis();
         const op = {
             hash: 'abcdef0123456789',
@@ -218,7 +224,7 @@ describe('Stage H · _renderCurateRow', () => {
     });
 
     test('finalized vote row with no event_summary (uses hash prefix)', () => {
-        const fn = compileMethod('_renderCurateRow');
+        const fn = compileMethod('renderCurateRow');
         const stub = makeStubThis();
         const op = {
             hash: 'fedcba9876543210',
@@ -240,7 +246,7 @@ describe('Stage H · _renderCurateRow', () => {
 
 describe('Stage H · _renderCurateDetail', () => {
     test('release_bundle detail (open) with raw event JSON', () => {
-        const fn = compileMethod('_renderCurateDetail');
+        const fn = compileMethod('renderCurateDetail');
         const stub = makeStubThis();
         const container = document.createElement('div');
         const resp = {
@@ -262,7 +268,7 @@ describe('Stage H · _renderCurateDetail', () => {
     });
 
     test('add_claim detail (finalized) suppresses vote buttons', () => {
-        const fn = compileMethod('_renderCurateDetail');
+        const fn = compileMethod('renderCurateDetail');
         const stub = makeStubThis();
         const container = document.createElement('div');
         const resp = {
@@ -287,7 +293,7 @@ function op_for_detail() {
 
 describe('Stage H · _renderReleaseBundleDetail', () => {
     test('full release bundle with two groups, tracks, songs, and sources', () => {
-        const fn = compileMethod('_renderReleaseBundleDetail');
+        const fn = compileMethod('renderReleaseBundleDetail');
         const stub = makeStubThis();
         const container = document.createElement('div');
         const detail = {
@@ -344,7 +350,7 @@ describe('Stage H · _renderReleaseBundleDetail', () => {
     });
 
     test('minimal release (no labels, no groups, no tracks, no sources)', () => {
-        const fn = compileMethod('_renderReleaseBundleDetail');
+        const fn = compileMethod('renderReleaseBundleDetail');
         const stub = makeStubThis();
         const container = document.createElement('div');
         fn.call(stub, container, { release: { name: 'Solo EP' } });
@@ -358,7 +364,7 @@ describe('Stage H · _renderReleaseBundleDetail', () => {
 
 describe('Stage H · _renderClaimDetail', () => {
     test('add_claim with object value and url source', () => {
-        const fn = compileMethod('_renderClaimDetail');
+        const fn = compileMethod('renderClaimDetail');
         const stub = makeStubThis();
         const container = document.createElement('div');
         fn.call(stub, container, {
@@ -373,7 +379,7 @@ describe('Stage H · _renderClaimDetail', () => {
     });
 
     test('edit_claim with primitive value and string source', () => {
-        const fn = compileMethod('_renderClaimDetail');
+        const fn = compileMethod('renderClaimDetail');
         const stub = makeStubThis();
         const container = document.createElement('div');
         fn.call(stub, container, {

--- a/frontend/src/visualization/InfoPanelRenderer.js
+++ b/frontend/src/visualization/InfoPanelRenderer.js
@@ -1,0 +1,399 @@
+/**
+ * InfoPanelRenderer — DOM rendering for the info panel sections that were
+ * previously private methods on MusicGraph (the 2,562-line god class).
+ *
+ * Each method writes HTML into a caller-provided container element. The
+ * renderer is dependency-injected with the small set of MusicGraph callbacks
+ * its handlers need (graph navigation, release navigation, curate row
+ * selection, voting), so the module has no implicit `this` coupling to
+ * MusicGraph beyond the explicit `callbacks` object.
+ *
+ * Public API:
+ *   renderSongDetails(song, titleElement, contentElement)
+ *   renderCurateRow(op)                             → HTMLElement
+ *   renderCurateDetail(container, resp, op)
+ *   renderReleaseBundleDetail(container, detail)
+ *   renderClaimDetail(container, detail)
+ *   escapeHtml(str)                                 → string
+ *   detailField(label, value)                       → string (HTML)
+ *
+ * Snapshot contract: the HTML produced by these methods is locked by
+ * `backend/test/visualization/musicGraphRenders.snapshot.test.js`. If you
+ * change the markup, snapshots will diff — investigate before updating.
+ *
+ * @module visualization/InfoPanelRenderer
+ */
+
+export class InfoPanelRenderer {
+    /**
+     * @param {Object} callbacks
+     * @param {(container: Element) => void} callbacks.attachNavLinkListeners
+     *   Wire `.info-nav-link` clicks to graph navigation. Lives on MusicGraph
+     *   because it's also used by render methods that haven't been moved here
+     *   (renderGroupDetails, renderPersonDetails).
+     * @param {(releaseId: string) => void} callbacks.navigateToRelease
+     * @param {(op: Object) => void} callbacks.selectCurateOperation
+     * @param {(op: Object, val: number) => void} callbacks.voteFromDetail
+     */
+    constructor(callbacks) {
+        this.callbacks = callbacks;
+    }
+
+    /**
+     * Render song details in the info panel.
+     * Shows songwriters, lyrics, and clickable releases.
+     */
+    renderSongDetails(song, titleElement, contentElement) {
+        const esc = v => String(v ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+        titleElement.textContent = song.title || song.name || 'Unknown Song';
+
+        let html = '';
+        html += `<p class="info-meta"><strong>Type:</strong> Song (Composition)</p>`;
+
+        // Songwriters
+        const writers = song.writers || [];
+        if (writers.length > 0) {
+            html += `<div class="info-section"><h4>Songwriters</h4><ul class="info-list">`;
+            writers.forEach(w => {
+                const nameHtml = w.person_id
+                    ? `<a href="#" class="info-nav-link" data-node-id="${esc(w.person_id)}">${esc(w.writer)}</a>`
+                    : esc(w.writer);
+                html += `<li>${nameHtml}</li>`;
+            });
+            html += `</ul></div>`;
+        }
+
+        // Lyrics
+        if (song.lyrics) {
+            html += `<div class="info-section"><h4>Lyrics</h4><pre class="info-lyrics">${esc(song.lyrics)}</pre></div>`;
+        }
+
+        // Releases (clickable)
+        const releases = song.releases || [];
+        if (releases.length > 0) {
+            html += `<div class="info-section"><h4>Appears On</h4><ul class="info-list">`;
+            releases.forEach(r => {
+                const date = r.release_date ? ` (${esc(r.release_date.substring(0, 4))})` : '';
+                html += `<li><a href="#" class="info-nav-link song-release-link" data-release-id="${esc(r.release_id)}">${esc(r.release)}</a>${date}</li>`;
+            });
+            html += `</ul></div>`;
+        }
+
+        contentElement.innerHTML = html;
+
+        // Attach click handlers for songwriter navigation
+        this.callbacks.attachNavLinkListeners(contentElement);
+
+        // Attach click handlers for release navigation
+        contentElement.querySelectorAll('.song-release-link').forEach(link => {
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                const releaseId = link.dataset.releaseId;
+                if (releaseId) this.callbacks.navigateToRelease(releaseId);
+            });
+        });
+    }
+
+    renderCurateRow(op) {
+        const row = document.createElement('div');
+        row.className = 'curate-row';
+        row.dataset.hash = op.hash;
+
+        const typeNames = {
+            21: 'Release', 30: 'Add Claim', 31: 'Edit Claim',
+            40: 'Vote', 41: 'Like', 50: 'Finalize', 60: 'Merge'
+        };
+        const typeName = typeNames[op.type] || `Type ${op.type}`;
+
+        const summary = op.event_summary;
+        let title = summary?.release_name || summary?.group_name || op.hash.substring(0, 12) + '...';
+
+        const ts = op.ts ? new Date(op.ts + 'Z') : null;
+        const timeStr = ts ? ts.toLocaleDateString([], { month: 'short', day: 'numeric' }) : '';
+
+        const tally = op.tally || { up_weight: 0, down_weight: 0, up_voter_count: 0, down_voter_count: 0 };
+        const netScore = tally.up_weight - tally.down_weight;
+
+        const statusClass = op.finalized ? 'curate-status--finalized' : '';
+        const statusLabel = op.finalized ? 'Finalized' : 'Open';
+
+        row.innerHTML = `
+            <div class="curate-row__header">
+                <span class="curate-type-badge curate-type-${op.type}">${typeName}</span>
+                <span class="curate-row__title">${this.escapeHtml(title)}</span>
+                <span class="curate-row__time">${timeStr}</span>
+            </div>
+            <div class="curate-row__author">by ${this.escapeHtml(op.author)}</div>
+            <div class="curate-row__tally">
+                <span class="curate-score ${netScore > 0 ? 'curate-score--positive' : netScore < 0 ? 'curate-score--negative' : ''}">
+                    ${netScore > 0 ? '+' : ''}${netScore}
+                </span>
+                <span class="curate-voters">
+                    <span class="curate-up">${tally.up_weight} (${tally.up_voter_count})</span>
+                    /
+                    <span class="curate-down">${tally.down_weight} (${tally.down_voter_count})</span>
+                </span>
+                <span class="curate-status ${statusClass}">${statusLabel}</span>
+            </div>
+        `;
+
+        // Click row to show detail (not the vote buttons)
+        row.addEventListener('click', () => this.callbacks.selectCurateOperation(op));
+
+        return row;
+    }
+
+    renderCurateDetail(container, resp, op) {
+        container.innerHTML = '';
+
+        const operation = resp.operation || {};
+        const tally = resp.tally || { up_weight: 0, down_weight: 0, up_voter_count: 0, down_voter_count: 0 };
+        const detail = resp.detail;
+        const event = resp.event;
+        const viewerVote = resp.viewer_vote;
+
+        // Header
+        const header = document.createElement('div');
+        header.className = 'curate-detail-header';
+        header.innerHTML = `
+            <h3>${this.escapeHtml(operation.type_name || 'Operation')}</h3>
+            <div class="curate-detail-meta">
+                <span>by ${this.escapeHtml(operation.author || '?')}</span>
+                <span>${operation.ts ? new Date(operation.ts + 'Z').toLocaleString() : ''}</span>
+                <span>${operation.finalized ? 'Finalized' : 'Open'}</span>
+            </div>
+        `;
+        container.appendChild(header);
+
+        // Voting controls in detail pane
+        const netScore = tally.up_weight - tally.down_weight;
+        const votingDiv = document.createElement('div');
+        votingDiv.className = 'curate-detail-voting';
+        votingDiv.innerHTML = `
+            <span class="curate-score ${netScore > 0 ? 'curate-score--positive' : netScore < 0 ? 'curate-score--negative' : ''}">
+                ${netScore > 0 ? '+' : ''}${netScore}
+            </span>
+            <span class="curate-voters">
+                <span class="curate-up">${tally.up_weight} (${tally.up_voter_count})</span> /
+                <span class="curate-down">${tally.down_weight} (${tally.down_voter_count})</span>
+            </span>
+        `;
+
+        if (!operation.finalized) {
+            const upBtn = document.createElement('button');
+            upBtn.className = 'curate-vote-btn curate-vote-up' + (viewerVote?.val === 1 ? ' curate-vote-btn--active' : '');
+            upBtn.textContent = viewerVote?.val === 1 ? 'Upvoted' : 'Upvote';
+            upBtn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                this.callbacks.voteFromDetail(op, 1);
+            });
+
+            const downBtn = document.createElement('button');
+            downBtn.className = 'curate-vote-btn curate-vote-down' + (viewerVote?.val === -1 ? ' curate-vote-btn--active' : '');
+            downBtn.textContent = viewerVote?.val === -1 ? 'Downvoted' : 'Downvote';
+            downBtn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                this.callbacks.voteFromDetail(op, -1);
+            });
+
+            votingDiv.appendChild(upBtn);
+            votingDiv.appendChild(downBtn);
+        }
+        container.appendChild(votingDiv);
+
+        // Body: type-specific rendering
+        const body = document.createElement('div');
+        body.className = 'curate-detail-body';
+
+        if (detail?.type === 'release_bundle') {
+            this.renderReleaseBundleDetail(body, detail);
+        } else if (detail?.type === 'add_claim' || detail?.type === 'edit_claim') {
+            this.renderClaimDetail(body, detail);
+        } else if (detail) {
+            body.innerHTML = '<p style="color:#888">Unsupported operation type for detailed view.</p>';
+        } else {
+            body.innerHTML = '<p style="color:#888">No event payload available.</p>';
+        }
+
+        container.appendChild(body);
+
+        // Raw JSON toggle
+        if (event) {
+            const rawSection = document.createElement('div');
+            rawSection.className = 'curate-raw-json';
+            rawSection.innerHTML = `
+                <details>
+                    <summary>Raw Event JSON</summary>
+                    <pre>${this.escapeHtml(JSON.stringify(event, null, 2))}</pre>
+                </details>
+            `;
+            body.appendChild(rawSection);
+        }
+    }
+
+    renderReleaseBundleDetail(container, detail) {
+        const rel = detail.release || {};
+
+        // Release info section
+        const releaseSection = document.createElement('div');
+        releaseSection.className = 'curate-section';
+        let releaseHtml = '<h4>Release</h4>';
+        releaseHtml += this.detailField('Name', rel.name);
+        if (rel.release_date) releaseHtml += this.detailField('Date', rel.release_date);
+        if (rel.format) releaseHtml += this.detailField('Format', rel.format);
+        if (rel.alt_names?.length) releaseHtml += this.detailField('Alt Names', rel.alt_names.join(', '));
+        if (rel.master_id) releaseHtml += this.detailField('Master ID', rel.master_id);
+        releaseSection.innerHTML = releaseHtml;
+        container.appendChild(releaseSection);
+
+        // Labels
+        if (rel.labels?.length) {
+            const labelsSection = document.createElement('div');
+            labelsSection.className = 'curate-section';
+            let html = '<h4>Labels</h4>';
+            for (const l of rel.labels) {
+                html += `<div class="curate-field-value">${this.escapeHtml(l.name)}${l.label_id ? ` <span style="color:#666">(${this.escapeHtml(l.label_id)})</span>` : ''}</div>`;
+            }
+            labelsSection.innerHTML = html;
+            container.appendChild(labelsSection);
+        }
+
+        // Groups
+        if (detail.groups?.length) {
+            const groupsSection = document.createElement('div');
+            groupsSection.className = 'curate-section';
+            let html = '<h4>Groups</h4>';
+            for (const g of detail.groups) {
+                html += `<div class="curate-field-value" style="margin-bottom:6px"><strong>${this.escapeHtml(g.name)}</strong>${g.group_id ? ` <span style="color:#666">(${this.escapeHtml(g.group_id)})</span>` : ''}</div>`;
+                if (g.members?.length) {
+                    html += '<div class="curate-person-list">';
+                    for (const m of g.members) {
+                        html += `<span class="curate-person-chip">${this.escapeHtml(m.name)}${m.roles?.length ? ` <span class="curate-role">${this.escapeHtml(m.roles.join(', '))}</span>` : ''}</span>`;
+                    }
+                    html += '</div>';
+                }
+            }
+            groupsSection.innerHTML = html;
+            container.appendChild(groupsSection);
+        }
+
+        // Release guests
+        if (rel.guests?.length) {
+            const guestsSection = document.createElement('div');
+            guestsSection.className = 'curate-section';
+            let html = '<h4>Release Personnel</h4><div class="curate-person-list">';
+            for (const g of rel.guests) {
+                html += `<span class="curate-person-chip">${this.escapeHtml(g.name)}${g.roles?.length ? ` <span class="curate-role">${this.escapeHtml(g.roles.join(', '))}</span>` : ''}</span>`;
+            }
+            html += '</div>';
+            guestsSection.innerHTML = html;
+            container.appendChild(guestsSection);
+        }
+
+        // Tracklist / tracks
+        if (detail.tracks?.length) {
+            const tracksSection = document.createElement('div');
+            tracksSection.className = 'curate-section';
+            let html = '<h4>Tracks</h4>';
+            for (let i = 0; i < detail.tracks.length; i++) {
+                const t = detail.tracks[i];
+                const pos = detail.tracklist?.[i]?.position || (i + 1);
+                html += '<div class="curate-track-item">';
+                html += `<div class="curate-track-title">${pos}. ${this.escapeHtml(t.title || 'Untitled')}${t.track_id ? ` <span style="color:#666;font-size:10px">${this.escapeHtml(t.track_id)}</span>` : ''}</div>`;
+
+                // Track groups
+                if (t.performed_by_groups?.length) {
+                    for (const g of t.performed_by_groups) {
+                        html += `<div class="curate-track-credits">Group: ${this.escapeHtml(g.name)}`;
+                        if (g.members?.length) {
+                            html += ' (' + g.members.map(m => this.escapeHtml(m.name)).join(', ') + ')';
+                        }
+                        html += '</div>';
+                    }
+                }
+
+                // Track guests
+                if (t.guests?.length) {
+                    html += `<div class="curate-track-credits">Guests: ${t.guests.map(g => this.escapeHtml(g.name) + (g.roles?.length ? ` (${this.escapeHtml(g.roles.join(', '))})` : '')).join(', ')}</div>`;
+                }
+
+                // Producers
+                if (t.producers?.length) {
+                    html += `<div class="curate-track-credits">Producers: ${t.producers.map(p => this.escapeHtml(p.name)).join(', ')}</div>`;
+                }
+
+                // Cover / Samples
+                if (t.cover_of_song_id) {
+                    html += `<div class="curate-track-credits">Cover of: ${this.escapeHtml(t.cover_of_song_id)}</div>`;
+                }
+                if (t.samples?.length) {
+                    html += `<div class="curate-track-credits">Samples: ${t.samples.map(s => this.escapeHtml(s.sampled_track_id || '')).join(', ')}</div>`;
+                }
+
+                // Listen links
+                if (t.listen_links?.length) {
+                    html += `<div class="curate-track-credits">Listen: ${t.listen_links.map(l => `<a href="${this.escapeHtml(l)}" target="_blank" style="color:#5c9cef">${this.escapeHtml(new URL(l).hostname)}</a>`).join(', ')}</div>`;
+                }
+
+                html += '</div>';
+            }
+            tracksSection.innerHTML = html;
+            container.appendChild(tracksSection);
+        }
+
+        // Songs
+        if (detail.songs?.length) {
+            const songsSection = document.createElement('div');
+            songsSection.className = 'curate-section';
+            let html = '<h4>Songs (Compositions)</h4>';
+            for (const s of detail.songs) {
+                html += `<div class="curate-field-value" style="margin-bottom:4px">${this.escapeHtml(s.title)}`;
+                if (s.writers?.length) {
+                    html += ` — ${s.writers.map(w => this.escapeHtml(w.name)).join(', ')}`;
+                }
+                html += '</div>';
+            }
+            songsSection.innerHTML = html;
+            container.appendChild(songsSection);
+        }
+
+        // Sources
+        if (detail.sources?.length) {
+            const srcSection = document.createElement('div');
+            srcSection.className = 'curate-section';
+            let html = '<h4>Sources</h4>';
+            for (const s of detail.sources) {
+                html += `<div class="curate-field-value"><a href="${this.escapeHtml(s.url || '')}" target="_blank" style="color:#5c9cef">${this.escapeHtml(s.url || '')}</a></div>`;
+            }
+            srcSection.innerHTML = html;
+            container.appendChild(srcSection);
+        }
+    }
+
+    renderClaimDetail(container, detail) {
+        const section = document.createElement('div');
+        section.className = 'curate-section';
+        let html = `<h4>${detail.type === 'edit_claim' ? 'Edit Claim' : 'Add Claim'}</h4>`;
+        if (detail.target_type) html += this.detailField('Target Type', detail.target_type);
+        if (detail.target_id) html += this.detailField('Target ID', detail.target_id);
+        if (detail.field) html += this.detailField('Field', detail.field);
+        if (detail.value !== undefined && detail.value !== null) {
+            const valStr = typeof detail.value === 'object' ? JSON.stringify(detail.value, null, 2) : String(detail.value);
+            html += this.detailField('Value', valStr);
+        }
+        if (detail.source) html += this.detailField('Source', typeof detail.source === 'object' ? detail.source.url || JSON.stringify(detail.source) : detail.source);
+        section.innerHTML = html;
+        container.appendChild(section);
+    }
+
+    detailField(label, value) {
+        if (!value) return '';
+        return `<div class="curate-field"><span class="curate-field-label">${this.escapeHtml(label)}</span><span class="curate-field-value">${this.escapeHtml(String(value))}</span></div>`;
+    }
+
+    escapeHtml(str) {
+        const div = document.createElement('div');
+        div.textContent = str;
+        return div.innerHTML;
+    }
+}

--- a/frontend/src/visualization/MusicGraph.js
+++ b/frontend/src/visualization/MusicGraph.js
@@ -17,6 +17,7 @@ import { PathTracker } from './PathTracker.js';
 import { LikeManager } from './LikeManager.js';
 import { ClaimManager } from './ClaimManager.js';
 import { ReleaseOrbitOverlay } from './ReleaseOrbitOverlay.js';
+import { InfoPanelRenderer } from './InfoPanelRenderer.js';
 import { api as backendApi } from '../utils/api.js';
 
 export class MusicGraph {
@@ -36,6 +37,12 @@ export class MusicGraph {
             api: this.api,
             onReleaseSelect: (details) => this._onOverlayReleaseSelect(details),
             onGuestClick: (personId) => this.navigateToNodeId(personId)
+        });
+        this.infoPanel = new InfoPanelRenderer({
+            attachNavLinkListeners: (container) => this._attachNavLinkListeners(container),
+            navigateToRelease: (releaseId) => this._navigateToRelease(releaseId),
+            selectCurateOperation: (op) => this._selectCurateOperation(op),
+            voteFromDetail: (op, val) => this._curateVoteFromDetail(op, val)
         });
 
         // State tracking
@@ -1963,66 +1970,11 @@ export class MusicGraph {
                 return;
             }
 
-            this._renderSongDetails(song, infoTitle, infoContent);
+            this.infoPanel.renderSongDetails(song, infoTitle, infoContent);
         } catch (error) {
             console.error('Failed to load song details:', error);
             infoContent.innerHTML = '<p>Error loading song details</p>';
         }
-    }
-
-    /**
-     * Render song details in the info panel.
-     * Shows songwriters, lyrics, and clickable releases.
-     */
-    _renderSongDetails(song, titleElement, contentElement) {
-        const esc = v => String(v ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
-        titleElement.textContent = song.title || song.name || 'Unknown Song';
-
-        let html = '';
-        html += `<p class="info-meta"><strong>Type:</strong> Song (Composition)</p>`;
-
-        // Songwriters
-        const writers = song.writers || [];
-        if (writers.length > 0) {
-            html += `<div class="info-section"><h4>Songwriters</h4><ul class="info-list">`;
-            writers.forEach(w => {
-                const nameHtml = w.person_id
-                    ? `<a href="#" class="info-nav-link" data-node-id="${esc(w.person_id)}">${esc(w.writer)}</a>`
-                    : esc(w.writer);
-                html += `<li>${nameHtml}</li>`;
-            });
-            html += `</ul></div>`;
-        }
-
-        // Lyrics
-        if (song.lyrics) {
-            html += `<div class="info-section"><h4>Lyrics</h4><pre class="info-lyrics">${esc(song.lyrics)}</pre></div>`;
-        }
-
-        // Releases (clickable)
-        const releases = song.releases || [];
-        if (releases.length > 0) {
-            html += `<div class="info-section"><h4>Appears On</h4><ul class="info-list">`;
-            releases.forEach(r => {
-                const date = r.release_date ? ` (${esc(r.release_date.substring(0, 4))})` : '';
-                html += `<li><a href="#" class="info-nav-link song-release-link" data-release-id="${esc(r.release_id)}">${esc(r.release)}</a>${date}</li>`;
-            });
-            html += `</ul></div>`;
-        }
-
-        contentElement.innerHTML = html;
-
-        // Attach click handlers for songwriter navigation
-        this._attachNavLinkListeners(contentElement);
-
-        // Attach click handlers for release navigation
-        contentElement.querySelectorAll('.song-release-link').forEach(link => {
-            link.addEventListener('click', (e) => {
-                e.preventDefault();
-                const releaseId = link.dataset.releaseId;
-                if (releaseId) this._navigateToRelease(releaseId);
-            });
-        });
     }
 
     // ========== Missing-node navigation ==========
@@ -2137,61 +2089,12 @@ export class MusicGraph {
             this._curateOperations = resp.operations;
             list.innerHTML = '';
             for (const op of resp.operations) {
-                list.appendChild(this._renderCurateRow(op));
+                list.appendChild(this.infoPanel.renderCurateRow(op));
             }
         } catch (e) {
             console.error('Failed to render curate panel:', e);
             list.innerHTML = '<div class="history-empty">Failed to load operations.</div>';
         }
-    }
-
-    _renderCurateRow(op) {
-        const row = document.createElement('div');
-        row.className = 'curate-row';
-        row.dataset.hash = op.hash;
-
-        const typeNames = {
-            21: 'Release', 30: 'Add Claim', 31: 'Edit Claim',
-            40: 'Vote', 41: 'Like', 50: 'Finalize', 60: 'Merge'
-        };
-        const typeName = typeNames[op.type] || `Type ${op.type}`;
-
-        const summary = op.event_summary;
-        let title = summary?.release_name || summary?.group_name || op.hash.substring(0, 12) + '...';
-
-        const ts = op.ts ? new Date(op.ts + 'Z') : null;
-        const timeStr = ts ? ts.toLocaleDateString([], { month: 'short', day: 'numeric' }) : '';
-
-        const tally = op.tally || { up_weight: 0, down_weight: 0, up_voter_count: 0, down_voter_count: 0 };
-        const netScore = tally.up_weight - tally.down_weight;
-
-        const statusClass = op.finalized ? 'curate-status--finalized' : '';
-        const statusLabel = op.finalized ? 'Finalized' : 'Open';
-
-        row.innerHTML = `
-            <div class="curate-row__header">
-                <span class="curate-type-badge curate-type-${op.type}">${typeName}</span>
-                <span class="curate-row__title">${this._escapeHtml(title)}</span>
-                <span class="curate-row__time">${timeStr}</span>
-            </div>
-            <div class="curate-row__author">by ${this._escapeHtml(op.author)}</div>
-            <div class="curate-row__tally">
-                <span class="curate-score ${netScore > 0 ? 'curate-score--positive' : netScore < 0 ? 'curate-score--negative' : ''}">
-                    ${netScore > 0 ? '+' : ''}${netScore}
-                </span>
-                <span class="curate-voters">
-                    <span class="curate-up">${tally.up_weight} (${tally.up_voter_count})</span>
-                    /
-                    <span class="curate-down">${tally.down_weight} (${tally.down_voter_count})</span>
-                </span>
-                <span class="curate-status ${statusClass}">${statusLabel}</span>
-            </div>
-        `;
-
-        // Click row to show detail (not the vote buttons)
-        row.addEventListener('click', () => this._selectCurateOperation(op));
-
-        return row;
     }
 
     async _selectCurateOperation(op) {
@@ -2217,259 +2120,11 @@ export class MusicGraph {
                 return;
             }
 
-            this._renderCurateDetail(detail, resp, op);
+            this.infoPanel.renderCurateDetail(detail, resp, op);
         } catch (e) {
             console.error('Failed to load operation detail:', e);
             detail.innerHTML = '<div class="curate-detail-empty"><p>Error loading detail.</p></div>';
         }
-    }
-
-    _renderCurateDetail(container, resp, op) {
-        container.innerHTML = '';
-
-        const operation = resp.operation || {};
-        const tally = resp.tally || { up_weight: 0, down_weight: 0, up_voter_count: 0, down_voter_count: 0 };
-        const detail = resp.detail;
-        const event = resp.event;
-        const viewerVote = resp.viewer_vote;
-
-        // Header
-        const header = document.createElement('div');
-        header.className = 'curate-detail-header';
-        header.innerHTML = `
-            <h3>${this._escapeHtml(operation.type_name || 'Operation')}</h3>
-            <div class="curate-detail-meta">
-                <span>by ${this._escapeHtml(operation.author || '?')}</span>
-                <span>${operation.ts ? new Date(operation.ts + 'Z').toLocaleString() : ''}</span>
-                <span>${operation.finalized ? 'Finalized' : 'Open'}</span>
-            </div>
-        `;
-        container.appendChild(header);
-
-        // Voting controls in detail pane
-        const netScore = tally.up_weight - tally.down_weight;
-        const votingDiv = document.createElement('div');
-        votingDiv.className = 'curate-detail-voting';
-        votingDiv.innerHTML = `
-            <span class="curate-score ${netScore > 0 ? 'curate-score--positive' : netScore < 0 ? 'curate-score--negative' : ''}">
-                ${netScore > 0 ? '+' : ''}${netScore}
-            </span>
-            <span class="curate-voters">
-                <span class="curate-up">${tally.up_weight} (${tally.up_voter_count})</span> /
-                <span class="curate-down">${tally.down_weight} (${tally.down_voter_count})</span>
-            </span>
-        `;
-
-        if (!operation.finalized) {
-            const upBtn = document.createElement('button');
-            upBtn.className = 'curate-vote-btn curate-vote-up' + (viewerVote?.val === 1 ? ' curate-vote-btn--active' : '');
-            upBtn.textContent = viewerVote?.val === 1 ? 'Upvoted' : 'Upvote';
-            upBtn.addEventListener('click', (e) => {
-                e.stopPropagation();
-                this._curateVoteFromDetail(op, 1);
-            });
-
-            const downBtn = document.createElement('button');
-            downBtn.className = 'curate-vote-btn curate-vote-down' + (viewerVote?.val === -1 ? ' curate-vote-btn--active' : '');
-            downBtn.textContent = viewerVote?.val === -1 ? 'Downvoted' : 'Downvote';
-            downBtn.addEventListener('click', (e) => {
-                e.stopPropagation();
-                this._curateVoteFromDetail(op, -1);
-            });
-
-            votingDiv.appendChild(upBtn);
-            votingDiv.appendChild(downBtn);
-        }
-        container.appendChild(votingDiv);
-
-        // Body: type-specific rendering
-        const body = document.createElement('div');
-        body.className = 'curate-detail-body';
-
-        if (detail?.type === 'release_bundle') {
-            this._renderReleaseBundleDetail(body, detail);
-        } else if (detail?.type === 'add_claim' || detail?.type === 'edit_claim') {
-            this._renderClaimDetail(body, detail);
-        } else if (detail) {
-            body.innerHTML = '<p style="color:#888">Unsupported operation type for detailed view.</p>';
-        } else {
-            body.innerHTML = '<p style="color:#888">No event payload available.</p>';
-        }
-
-        container.appendChild(body);
-
-        // Raw JSON toggle
-        if (event) {
-            const rawSection = document.createElement('div');
-            rawSection.className = 'curate-raw-json';
-            rawSection.innerHTML = `
-                <details>
-                    <summary>Raw Event JSON</summary>
-                    <pre>${this._escapeHtml(JSON.stringify(event, null, 2))}</pre>
-                </details>
-            `;
-            body.appendChild(rawSection);
-        }
-    }
-
-    _renderReleaseBundleDetail(container, detail) {
-        const rel = detail.release || {};
-
-        // Release info section
-        const releaseSection = document.createElement('div');
-        releaseSection.className = 'curate-section';
-        let releaseHtml = '<h4>Release</h4>';
-        releaseHtml += this._detailField('Name', rel.name);
-        if (rel.release_date) releaseHtml += this._detailField('Date', rel.release_date);
-        if (rel.format) releaseHtml += this._detailField('Format', rel.format);
-        if (rel.alt_names?.length) releaseHtml += this._detailField('Alt Names', rel.alt_names.join(', '));
-        if (rel.master_id) releaseHtml += this._detailField('Master ID', rel.master_id);
-        releaseSection.innerHTML = releaseHtml;
-        container.appendChild(releaseSection);
-
-        // Labels
-        if (rel.labels?.length) {
-            const labelsSection = document.createElement('div');
-            labelsSection.className = 'curate-section';
-            let html = '<h4>Labels</h4>';
-            for (const l of rel.labels) {
-                html += `<div class="curate-field-value">${this._escapeHtml(l.name)}${l.label_id ? ` <span style="color:#666">(${this._escapeHtml(l.label_id)})</span>` : ''}</div>`;
-            }
-            labelsSection.innerHTML = html;
-            container.appendChild(labelsSection);
-        }
-
-        // Groups
-        if (detail.groups?.length) {
-            const groupsSection = document.createElement('div');
-            groupsSection.className = 'curate-section';
-            let html = '<h4>Groups</h4>';
-            for (const g of detail.groups) {
-                html += `<div class="curate-field-value" style="margin-bottom:6px"><strong>${this._escapeHtml(g.name)}</strong>${g.group_id ? ` <span style="color:#666">(${this._escapeHtml(g.group_id)})</span>` : ''}</div>`;
-                if (g.members?.length) {
-                    html += '<div class="curate-person-list">';
-                    for (const m of g.members) {
-                        html += `<span class="curate-person-chip">${this._escapeHtml(m.name)}${m.roles?.length ? ` <span class="curate-role">${this._escapeHtml(m.roles.join(', '))}</span>` : ''}</span>`;
-                    }
-                    html += '</div>';
-                }
-            }
-            groupsSection.innerHTML = html;
-            container.appendChild(groupsSection);
-        }
-
-        // Release guests
-        if (rel.guests?.length) {
-            const guestsSection = document.createElement('div');
-            guestsSection.className = 'curate-section';
-            let html = '<h4>Release Personnel</h4><div class="curate-person-list">';
-            for (const g of rel.guests) {
-                html += `<span class="curate-person-chip">${this._escapeHtml(g.name)}${g.roles?.length ? ` <span class="curate-role">${this._escapeHtml(g.roles.join(', '))}</span>` : ''}</span>`;
-            }
-            html += '</div>';
-            guestsSection.innerHTML = html;
-            container.appendChild(guestsSection);
-        }
-
-        // Tracklist / tracks
-        if (detail.tracks?.length) {
-            const tracksSection = document.createElement('div');
-            tracksSection.className = 'curate-section';
-            let html = '<h4>Tracks</h4>';
-            for (let i = 0; i < detail.tracks.length; i++) {
-                const t = detail.tracks[i];
-                const pos = detail.tracklist?.[i]?.position || (i + 1);
-                html += '<div class="curate-track-item">';
-                html += `<div class="curate-track-title">${pos}. ${this._escapeHtml(t.title || 'Untitled')}${t.track_id ? ` <span style="color:#666;font-size:10px">${this._escapeHtml(t.track_id)}</span>` : ''}</div>`;
-
-                // Track groups
-                if (t.performed_by_groups?.length) {
-                    for (const g of t.performed_by_groups) {
-                        html += `<div class="curate-track-credits">Group: ${this._escapeHtml(g.name)}`;
-                        if (g.members?.length) {
-                            html += ' (' + g.members.map(m => this._escapeHtml(m.name)).join(', ') + ')';
-                        }
-                        html += '</div>';
-                    }
-                }
-
-                // Track guests
-                if (t.guests?.length) {
-                    html += `<div class="curate-track-credits">Guests: ${t.guests.map(g => this._escapeHtml(g.name) + (g.roles?.length ? ` (${this._escapeHtml(g.roles.join(', '))})` : '')).join(', ')}</div>`;
-                }
-
-                // Producers
-                if (t.producers?.length) {
-                    html += `<div class="curate-track-credits">Producers: ${t.producers.map(p => this._escapeHtml(p.name)).join(', ')}</div>`;
-                }
-
-                // Cover / Samples
-                if (t.cover_of_song_id) {
-                    html += `<div class="curate-track-credits">Cover of: ${this._escapeHtml(t.cover_of_song_id)}</div>`;
-                }
-                if (t.samples?.length) {
-                    html += `<div class="curate-track-credits">Samples: ${t.samples.map(s => this._escapeHtml(s.sampled_track_id || '')).join(', ')}</div>`;
-                }
-
-                // Listen links
-                if (t.listen_links?.length) {
-                    html += `<div class="curate-track-credits">Listen: ${t.listen_links.map(l => `<a href="${this._escapeHtml(l)}" target="_blank" style="color:#5c9cef">${this._escapeHtml(new URL(l).hostname)}</a>`).join(', ')}</div>`;
-                }
-
-                html += '</div>';
-            }
-            tracksSection.innerHTML = html;
-            container.appendChild(tracksSection);
-        }
-
-        // Songs
-        if (detail.songs?.length) {
-            const songsSection = document.createElement('div');
-            songsSection.className = 'curate-section';
-            let html = '<h4>Songs (Compositions)</h4>';
-            for (const s of detail.songs) {
-                html += `<div class="curate-field-value" style="margin-bottom:4px">${this._escapeHtml(s.title)}`;
-                if (s.writers?.length) {
-                    html += ` — ${s.writers.map(w => this._escapeHtml(w.name)).join(', ')}`;
-                }
-                html += '</div>';
-            }
-            songsSection.innerHTML = html;
-            container.appendChild(songsSection);
-        }
-
-        // Sources
-        if (detail.sources?.length) {
-            const srcSection = document.createElement('div');
-            srcSection.className = 'curate-section';
-            let html = '<h4>Sources</h4>';
-            for (const s of detail.sources) {
-                html += `<div class="curate-field-value"><a href="${this._escapeHtml(s.url || '')}" target="_blank" style="color:#5c9cef">${this._escapeHtml(s.url || '')}</a></div>`;
-            }
-            srcSection.innerHTML = html;
-            container.appendChild(srcSection);
-        }
-    }
-
-    _renderClaimDetail(container, detail) {
-        const section = document.createElement('div');
-        section.className = 'curate-section';
-        let html = `<h4>${detail.type === 'edit_claim' ? 'Edit Claim' : 'Add Claim'}</h4>`;
-        if (detail.target_type) html += this._detailField('Target Type', detail.target_type);
-        if (detail.target_id) html += this._detailField('Target ID', detail.target_id);
-        if (detail.field) html += this._detailField('Field', detail.field);
-        if (detail.value !== undefined && detail.value !== null) {
-            const valStr = typeof detail.value === 'object' ? JSON.stringify(detail.value, null, 2) : String(detail.value);
-            html += this._detailField('Value', valStr);
-        }
-        if (detail.source) html += this._detailField('Source', typeof detail.source === 'object' ? detail.source.url || JSON.stringify(detail.source) : detail.source);
-        section.innerHTML = html;
-        container.appendChild(section);
-    }
-
-    _detailField(label, value) {
-        if (!value) return '';
-        return `<div class="curate-field"><span class="curate-field-label">${this._escapeHtml(label)}</span><span class="curate-field-value">${this._escapeHtml(String(value))}</span></div>`;
     }
 
     async _curateVoteFromDetail(op, val) {
@@ -2526,19 +2181,13 @@ export class MusicGraph {
             const list = document.getElementById('curate-list');
             const oldRow = list?.querySelector(`[data-hash="${op.hash}"]`);
             if (oldRow) {
-                const newRow = this._renderCurateRow(op);
+                const newRow = this.infoPanel.renderCurateRow(op);
                 newRow.classList.add('curate-row--selected');
                 oldRow.replaceWith(newRow);
             }
         } catch (e) {
             console.error('Failed to refresh tally:', e);
         }
-    }
-
-    _escapeHtml(str) {
-        const div = document.createElement('div');
-        div.textContent = str;
-        return div.innerHTML;
     }
 
     /**


### PR DESCRIPTION
Pulls the five info-panel render methods and their two HTML helpers out of the 2562-line MusicGraph god class into a dedicated `frontend/src/visualization/InfoPanelRenderer.js` module.

Methods moved (and renamed without the `_` prefix, since they are now the renderer's public API):
- renderSongDetails        (was _renderSongDetails)
- renderCurateRow          (was _renderCurateRow)
- renderCurateDetail       (was _renderCurateDetail)
- renderReleaseBundleDetail (was _renderReleaseBundleDetail)
- renderClaimDetail        (was _renderClaimDetail)
- escapeHtml               (was _escapeHtml)
- detailField              (was _detailField)

The renderer takes its four MusicGraph-side dependencies as constructor callbacks rather than reaching through `this`:

    new InfoPanelRenderer({
      attachNavLinkListeners,   // shared helper still on MusicGraph
                                // (renderGroupDetails / renderPersonDetails
                                //  also use it)
      navigateToRelease,
      selectCurateOperation,
      voteFromDetail,
    })

Stage H's frontend characterization test (10 snapshots / 15 tests) is the contract here. Updated it to:
  - point at InfoPanelRenderer.js instead of MusicGraph.js
  - drift-guard against the renamed signatures
  - stub `escapeHtml` / `detailField` directly on the test `this` and put the four nav callbacks under `this.callbacks.*`

The snapshot files are untouched — every byte of HTML the renderer emits is identical to the pre-extraction baseline. Verified:
  - frontend snapshot test: 15 passed / 10 snapshots matched
  - full backend suite:     484 passed / 218 skipped / 30 snapshots
                             — identical to baseline

MusicGraph.js: 2562 → 2211 lines (-351). InfoPanelRenderer.js: 399 lines.

The remaining handoff-listed extractions (FavoritesManager, OverlayPositioner, GraphDataLoader) are intentionally deferred — they have no characterization-test coverage, so moving them in this commit would be flying blind. They can land in follow-up commits once a matching snapshot net exists, which the original Stage H plan also called out.

https://claude.ai/code/session_01D7qa8hTDkDUKjew7Hmau9d