### PR TITLE
test(visualization): characterization tests for Stage J.2 extractions

### DIFF
--- a/backend/test/visualization/__snapshots__/favoritesManager.snapshot.test.js.snap
+++ b/backend/test/visualization/__snapshots__/favoritesManager.snapshot.test.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Stage J.2 · renderFavoritesPanel connected with zero rows → shows "No favorites yet.": zero-rows 1`] = `"<li class="history-empty">No favorites yet.</li>"`;
+
+exports[`Stage J.2 · renderFavoritesPanel fetch failure → shows "Failed to load favorites.": fetch-error 1`] = `"<li class="history-empty">Failed to load favorites.</li>"`;
+
+exports[`Stage J.2 · renderFavoritesPanel rows missing from hashIndex → shows truncated hash + disabled style: without-hashindex 1`] = `
+"<li class="history-item" style="opacity:0.6; cursor:not-allowed;" data-node-id="">
+                    <span class="history-type-badge history-type-unknown">unknown</span>
+                    <span class="history-name">01234567…</span>
+                    <span class="history-time"></span>
+                </li><li class="history-item" style="opacity:0.6; cursor:not-allowed;" data-node-id="">
+                    <span class="history-type-badge history-type-unknown">unknown</span>
+                    <span class="history-name">fedcba98…</span>
+                    <span class="history-time"></span>
+                </li>"
+`;
+
+exports[`Stage J.2 · renderFavoritesPanel rows resolve through hashIndex → renders type badges and names: with-hashindex 1`] = `
+"<li class="history-item" data-node-id="group:beatles">
+                    <span class="history-type-badge history-type-group">group</span>
+                    <span class="history-name">The Beatles</span>
+                    <span class="history-time"></span>
+                </li><li class="history-item" data-node-id="person:lennon">
+                    <span class="history-type-badge history-type-person">person</span>
+                    <span class="history-name">John Lennon</span>
+                    <span class="history-time"></span>
+                </li><li class="history-item" data-node-id="release:abbey">
+                    <span class="history-type-badge history-type-release">release</span>
+                    <span class="history-name">Abbey Road</span>
+                    <span class="history-time"></span>
+                </li>"
+`;
+
+exports[`Stage J.2 · renderFavoritesPanel wallet not connected → shows "Login to see your favorites.": not-connected 1`] = `"<li class="history-empty">Login to see your favorites.</li>"`;

--- a/backend/test/visualization/favoritesManager.snapshot.test.js
+++ b/backend/test/visualization/favoritesManager.snapshot.test.js
@@ -1,0 +1,379 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Stage J.2 — FavoritesManager characterization tests.
+ *
+ * Locks the behavior of the favorites cluster on MusicGraph so the
+ * upcoming FavoritesManager extraction (~150 lines, currently lines
+ * ~1735–1803 of MusicGraph.js) cannot silently change observable
+ * behavior. These methods cluster cleanly around the
+ * `chainFavorites: Set` and `chainFavoritesLoaded: boolean` state plus
+ * the `#favorites-count` and `#favorites-panel` DOM elements.
+ *
+ * Methods covered:
+ *   updateFavoritesCount()            — writes count to #favorites-count
+ *   refreshFavoritesFromChain()       — fetches account likes, populates Set
+ *   toggleFavoritesPanel()            — flips state, shows/hides panel,
+ *                                       triggers render on open
+ *   renderFavoritesPanel()            — renders <li> rows; HTML snapshot
+ *
+ * Strategy: source-extract + isolated invoke (same as the Stage H
+ * InfoPanelRenderer test). We compile each method body via `new Function`
+ * and call it with `Function.prototype.call(stubThis, ...)`. Snapshot
+ * the resulting innerHTML / Set contents / call ledger so the upcoming
+ * extraction must reproduce them byte-for-byte.
+ */
+
+import { jest } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import { parse } from '@babel/parser';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const MUSIC_GRAPH_PATH = resolve(__dirname, '../../../frontend/src/visualization/MusicGraph.js');
+const SOURCE = readFileSync(MUSIC_GRAPH_PATH, 'utf8');
+
+// ---------------------------------------------------------------------------
+// AST extraction (same machinery as the Stage H test).
+// ---------------------------------------------------------------------------
+
+const AST = parse(SOURCE, { sourceType: 'module', plugins: ['classProperties'] });
+
+const METHOD_INDEX = (() => {
+    const map = new Map();
+    function visit(node) {
+        if (!node || typeof node !== 'object') return;
+        if (node.type === 'ClassMethod' && node.key?.type === 'Identifier') {
+            map.set(node.key.name, node);
+        }
+        for (const key of Object.keys(node)) {
+            const v = node[key];
+            if (Array.isArray(v)) v.forEach(visit);
+            else if (v && typeof v === 'object' && v.type) visit(v);
+        }
+    }
+    visit(AST);
+    return map;
+})();
+
+function extractMethod(name) {
+    const node = METHOD_INDEX.get(name);
+    if (!node) throw new Error(`extractMethod: ${name} not found in MusicGraph.js`);
+    const params = node.params.map(p => SOURCE.slice(p.start, p.end)).join(', ');
+    const body = SOURCE.slice(node.body.start + 1, node.body.end - 1);
+    const isAsync = !!node.async;
+    return { params, body, isAsync };
+}
+
+function compileMethod(name) {
+    const { params, body, isAsync } = extractMethod(name);
+    const argNames = params.split(',').map(s => s.trim()).filter(Boolean);
+    if (isAsync) {
+        const AsyncFunction = (async function () {}).constructor;
+        return new AsyncFunction(...argNames, body);
+    }
+    // eslint-disable-next-line no-new-func
+    return new Function(...argNames, body);
+}
+
+// ---------------------------------------------------------------------------
+// Per-test DOM scaffolding. The favorites methods read/write three IDs:
+// #favorites-count, #favorites-panel, #favorites-list. We build a fresh
+// scaffold per test so state never leaks between cases.
+// ---------------------------------------------------------------------------
+
+function setupDOM() {
+    document.body.innerHTML = `
+        <div id="favorites-count">0</div>
+        <div id="favorites-panel" style="display: none;"></div>
+        <ul id="favorites-list"></ul>
+    `;
+}
+
+afterEach(() => {
+    document.body.innerHTML = '';
+});
+
+// ---------------------------------------------------------------------------
+// Stub `this` builder. The favorites methods reach into:
+//   - this.chainFavorites          (Set)
+//   - this.chainFavoritesLoaded    (boolean)
+//   - this.favoritesPanelOpen      (boolean)
+//   - this.walletManager           (object with isConnected())
+//   - this.likeManager             (object with fetchAccountLikes())
+//   - this.hashIndex               (Map node_id_hash → {nodeId, name, type})
+//   - this.escapeHtml(str)         (kept on MusicGraph; not part of InfoPanelRenderer)
+//   - this.navigateToNodeId(id)    (callback)
+//   - this.refreshFavoritesFromChain() / .updateFavoritesCount() /
+//     .renderFavoritesPanel()      (intra-cluster — wired via compileMethod)
+// ---------------------------------------------------------------------------
+
+function makeStub({
+    chainFavorites = new Set(),
+    chainFavoritesLoaded = false,
+    favoritesPanelOpen = false,
+    walletConnected = true,
+    accountLikes = [],
+    hashIndex = new Map(),
+    fetchAccountLikesImpl,
+} = {}) {
+    const stub = {
+        chainFavorites,
+        chainFavoritesLoaded,
+        favoritesPanelOpen,
+        hashIndex,
+        walletManager: {
+            isConnected: jest.fn(() => walletConnected),
+        },
+        likeManager: {
+            fetchAccountLikes: fetchAccountLikesImpl
+                ? jest.fn(fetchAccountLikesImpl)
+                : jest.fn(async () => accountLikes),
+        },
+        escapeHtml(str) {
+            const div = document.createElement('div');
+            div.textContent = str;
+            return div.innerHTML;
+        },
+        navigateToNodeId: jest.fn(),
+    };
+    // Intra-cluster delegations. Each method is its own compiled body so
+    // mutual calls go through the same source we're locking.
+    stub.updateFavoritesCount      = compileMethod('updateFavoritesCount').bind(stub);
+    stub.refreshFavoritesFromChain = compileMethod('refreshFavoritesFromChain').bind(stub);
+    stub.renderFavoritesPanel      = compileMethod('renderFavoritesPanel').bind(stub);
+    return stub;
+}
+
+// ---------------------------------------------------------------------------
+// Drift guard — if MusicGraph.js renames or moves these methods, fail loud.
+// ---------------------------------------------------------------------------
+
+describe('Stage J.2 · FavoritesManager · drift guard', () => {
+    test.each([
+        ['updateFavoritesCount',      '()'],
+        ['refreshFavoritesFromChain', '()'],
+        ['toggleFavoritesPanel',      '()'],
+        ['renderFavoritesPanel',      '()'],
+    ])('method %s exists with signature %s', (name, sig) => {
+        const expected = sig.slice(1, -1).split(',').map(s => s.trim()).filter(Boolean).join(', ');
+        const { params } = extractMethod(name);
+        const actual = params.split(',').map(s => s.trim()).filter(Boolean).join(', ');
+        expect(actual).toBe(expected);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// updateFavoritesCount
+// ---------------------------------------------------------------------------
+
+describe('Stage J.2 · updateFavoritesCount', () => {
+    test('writes Set size to #favorites-count', () => {
+        setupDOM();
+        const stub = makeStub({ chainFavorites: new Set(['a', 'b', 'c']) });
+        compileMethod('updateFavoritesCount').call(stub);
+        expect(document.getElementById('favorites-count').textContent).toBe('3');
+    });
+
+    test('writes "0" for empty Set', () => {
+        setupDOM();
+        const stub = makeStub();
+        compileMethod('updateFavoritesCount').call(stub);
+        expect(document.getElementById('favorites-count').textContent).toBe('0');
+    });
+
+    test('is a no-op when #favorites-count element is missing', () => {
+        document.body.innerHTML = '';  // no scaffold
+        const stub = makeStub({ chainFavorites: new Set(['a']) });
+        expect(() => compileMethod('updateFavoritesCount').call(stub)).not.toThrow();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// refreshFavoritesFromChain
+// ---------------------------------------------------------------------------
+
+describe('Stage J.2 · refreshFavoritesFromChain', () => {
+    test('replaces chainFavorites Set with node_ids from rows', async () => {
+        setupDOM();
+        const stub = makeStub({
+            chainFavorites: new Set(['stale1', 'stale2']),
+            accountLikes: [
+                { node_id: 'hash:a' },
+                { node_id: 'hash:b' },
+                { node_id: 'hash:c' },
+            ],
+        });
+
+        const rows = await compileMethod('refreshFavoritesFromChain').call(stub);
+
+        expect([...stub.chainFavorites].sort()).toEqual(['hash:a', 'hash:b', 'hash:c']);
+        expect(stub.chainFavoritesLoaded).toBe(true);
+        expect(rows).toHaveLength(3);
+    });
+
+    test('passes 200 as the limit to fetchAccountLikes', async () => {
+        setupDOM();
+        const stub = makeStub();
+        await compileMethod('refreshFavoritesFromChain').call(stub);
+        expect(stub.likeManager.fetchAccountLikes).toHaveBeenCalledWith(200);
+    });
+
+    test('updates #favorites-count side-effect', async () => {
+        setupDOM();
+        const stub = makeStub({
+            accountLikes: [{ node_id: 'h1' }, { node_id: 'h2' }],
+        });
+        await compileMethod('refreshFavoritesFromChain').call(stub);
+        expect(document.getElementById('favorites-count').textContent).toBe('2');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// toggleFavoritesPanel
+// ---------------------------------------------------------------------------
+
+describe('Stage J.2 · toggleFavoritesPanel', () => {
+    test('flips closed → open: shows panel and calls renderFavoritesPanel', () => {
+        setupDOM();
+        const stub = makeStub({ favoritesPanelOpen: false });
+        // Spy on renderFavoritesPanel without actually executing it (jsdom-safe).
+        stub.renderFavoritesPanel = jest.fn();
+
+        compileMethod('toggleFavoritesPanel').call(stub);
+
+        expect(stub.favoritesPanelOpen).toBe(true);
+        expect(document.getElementById('favorites-panel').style.display).toBe('flex');
+        expect(stub.renderFavoritesPanel).toHaveBeenCalledTimes(1);
+    });
+
+    test('flips open → closed: hides panel and does NOT call render', () => {
+        setupDOM();
+        const stub = makeStub({ favoritesPanelOpen: true });
+        stub.renderFavoritesPanel = jest.fn();
+
+        compileMethod('toggleFavoritesPanel').call(stub);
+
+        expect(stub.favoritesPanelOpen).toBe(false);
+        expect(document.getElementById('favorites-panel').style.display).toBe('none');
+        expect(stub.renderFavoritesPanel).not.toHaveBeenCalled();
+    });
+
+    test('is a no-op when #favorites-panel element is missing', () => {
+        document.body.innerHTML = '';
+        const stub = makeStub({ favoritesPanelOpen: false });
+        stub.renderFavoritesPanel = jest.fn();
+        // Note: state still flips before the missing-element early return —
+        // characterizing current behavior, not arguing it's correct.
+        compileMethod('toggleFavoritesPanel').call(stub);
+        expect(stub.favoritesPanelOpen).toBe(true);
+        expect(stub.renderFavoritesPanel).not.toHaveBeenCalled();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// renderFavoritesPanel — HTML snapshots across all four branches.
+// ---------------------------------------------------------------------------
+
+describe('Stage J.2 · renderFavoritesPanel', () => {
+    test('wallet not connected → shows "Login to see your favorites."', async () => {
+        setupDOM();
+        const stub = makeStub({ walletConnected: false });
+        await compileMethod('renderFavoritesPanel').call(stub);
+        expect(document.getElementById('favorites-list').innerHTML).toMatchSnapshot('not-connected');
+    });
+
+    test('connected with zero rows → shows "No favorites yet."', async () => {
+        setupDOM();
+        const stub = makeStub({ accountLikes: [] });
+        await compileMethod('renderFavoritesPanel').call(stub);
+        expect(document.getElementById('favorites-list').innerHTML).toMatchSnapshot('zero-rows');
+    });
+
+    test('rows resolve through hashIndex → renders type badges and names', async () => {
+        setupDOM();
+        const hashIndex = new Map([
+            ['hash:beatles',    { nodeId: 'group:beatles',  name: 'The Beatles', type: 'Group'  }],
+            ['hash:lennon',     { nodeId: 'person:lennon',  name: 'John Lennon', type: 'Person' }],
+            ['hash:abbeyroad',  { nodeId: 'release:abbey',  name: 'Abbey Road',  type: 'Release'}],
+        ]);
+        const stub = makeStub({
+            hashIndex,
+            accountLikes: [
+                { node_id: 'hash:beatles' },
+                { node_id: 'hash:lennon' },
+                { node_id: 'hash:abbeyroad' },
+            ],
+        });
+
+        await compileMethod('renderFavoritesPanel').call(stub);
+        expect(document.getElementById('favorites-list').innerHTML).toMatchSnapshot('with-hashindex');
+    });
+
+    test('rows missing from hashIndex → shows truncated hash + disabled style', async () => {
+        setupDOM();
+        const stub = makeStub({
+            hashIndex: new Map(),  // empty: every row falls to hash-prefix fallback
+            accountLikes: [
+                { node_id: '0123456789abcdefdeadbeef' },
+                { node_id: 'fedcba9876543210cafebabe' },
+            ],
+        });
+        await compileMethod('renderFavoritesPanel').call(stub);
+        expect(document.getElementById('favorites-list').innerHTML).toMatchSnapshot('without-hashindex');
+    });
+
+    test('clicking a resolved row calls navigateToNodeId(nodeId)', async () => {
+        setupDOM();
+        const hashIndex = new Map([
+            ['hash:beatles', { nodeId: 'group:beatles', name: 'The Beatles', type: 'Group' }],
+        ]);
+        const stub = makeStub({
+            hashIndex,
+            accountLikes: [{ node_id: 'hash:beatles' }],
+        });
+        await compileMethod('renderFavoritesPanel').call(stub);
+
+        const li = document.querySelector('.history-item');
+        li.click();
+        expect(stub.navigateToNodeId).toHaveBeenCalledWith('group:beatles');
+    });
+
+    test('unresolved rows have no click handler attached', async () => {
+        setupDOM();
+        const stub = makeStub({
+            hashIndex: new Map(),
+            accountLikes: [{ node_id: '0123456789abcdef' }],
+        });
+        await compileMethod('renderFavoritesPanel').call(stub);
+
+        const li = document.querySelector('.history-item');
+        expect(li.dataset.nodeId).toBe('');
+        li.click();
+        expect(stub.navigateToNodeId).not.toHaveBeenCalled();
+    });
+
+    test('fetch failure → shows "Failed to load favorites."', async () => {
+        setupDOM();
+        const stub = makeStub({
+            fetchAccountLikesImpl: async () => { throw new Error('chain RPC down'); },
+        });
+        // Quiet the error-log emitted by the catch branch.
+        const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        try {
+            await compileMethod('renderFavoritesPanel').call(stub);
+            expect(document.getElementById('favorites-list').innerHTML).toMatchSnapshot('fetch-error');
+        } finally {
+            errSpy.mockRestore();
+        }
+    });
+
+    test('is a no-op when #favorites-list element is missing', async () => {
+        document.body.innerHTML = '';
+        const stub = makeStub();
+        await expect(compileMethod('renderFavoritesPanel').call(stub)).resolves.toBeUndefined();
+        expect(stub.likeManager.fetchAccountLikes).not.toHaveBeenCalled();
+    });
+});

--- a/backend/test/visualization/graphDataLoader.snapshot.test.js
+++ b/backend/test/visualization/graphDataLoader.snapshot.test.js
@@ -1,0 +1,365 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Stage J.2 — GraphDataLoader characterization tests.
+ *
+ * Locks the behavior of the graph-loading cluster on MusicGraph so the
+ * upcoming GraphDataLoader extraction (~80 lines, currently lines
+ * ~1425–1499 + ~2016–2035 of MusicGraph.js) cannot silently change
+ * observable side effects. These methods are the single source of
+ * truth for `this.rawGraph`, `this.hashIndex`, and the JIT graph the
+ * Hypertree renders.
+ *
+ * Methods covered:
+ *   loadGraphData()                — initial fetch + render + hash-index rebuild
+ *   rebuildHashIndexFromRawGraph() — checksum256 → metadata mapping
+ *   ensureNodeInGraph(nodeId)      — neighborhood fetch + merge + 500-cap
+ *
+ * Strategy: source-extract + isolated invoke (same as the Stage H
+ * InfoPanelRenderer test). We compile each method body via `new Function`
+ * and call it with `Function.prototype.call(stubThis, ...)`. Assertions
+ * focus on mutated state (rawGraph, hashIndex, _initialParticipation)
+ * and outgoing call ledgers (api.fetchInitialGraphRaw,
+ * api.fetchNeighborhoodRaw, api.transformToJIT, api.mergeRawGraph,
+ * ht.loadJSON, ht.refresh, likeManager.nodeIdToChecksum256).
+ */
+
+import { jest } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import { parse } from '@babel/parser';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const MUSIC_GRAPH_PATH = resolve(__dirname, '../../../frontend/src/visualization/MusicGraph.js');
+const SOURCE = readFileSync(MUSIC_GRAPH_PATH, 'utf8');
+
+// ---------------------------------------------------------------------------
+// AST extraction (same machinery as the Stage H test).
+// ---------------------------------------------------------------------------
+
+const AST = parse(SOURCE, { sourceType: 'module', plugins: ['classProperties'] });
+
+const METHOD_INDEX = (() => {
+    const map = new Map();
+    function visit(node) {
+        if (!node || typeof node !== 'object') return;
+        if (node.type === 'ClassMethod' && node.key?.type === 'Identifier') {
+            map.set(node.key.name, node);
+        }
+        for (const key of Object.keys(node)) {
+            const v = node[key];
+            if (Array.isArray(v)) v.forEach(visit);
+            else if (v && typeof v === 'object' && v.type) visit(v);
+        }
+    }
+    visit(AST);
+    return map;
+})();
+
+function extractMethod(name) {
+    const node = METHOD_INDEX.get(name);
+    if (!node) throw new Error(`extractMethod: ${name} not found in MusicGraph.js`);
+    const params = node.params.map(p => SOURCE.slice(p.start, p.end)).join(', ');
+    const body = SOURCE.slice(node.body.start + 1, node.body.end - 1);
+    const isAsync = !!node.async;
+    return { params, body, isAsync };
+}
+
+function compileMethod(name) {
+    const { params, body, isAsync } = extractMethod(name);
+    const argNames = params.split(',').map(s => s.trim()).filter(Boolean);
+    if (isAsync) {
+        const AsyncFunction = (async function () {}).constructor;
+        return new AsyncFunction(...argNames, body);
+    }
+    // eslint-disable-next-line no-new-func
+    return new Function(...argNames, body);
+}
+
+// ---------------------------------------------------------------------------
+// Quiet console.log/error (loadGraphData is chatty by design).
+// ---------------------------------------------------------------------------
+
+let logSpy, errSpy, warnSpy;
+
+beforeEach(() => {
+    logSpy  = jest.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy  = jest.spyOn(console, 'error').mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    warnSpy.mockRestore();
+});
+
+// ---------------------------------------------------------------------------
+// Stub `this` builder. The loader methods reach into:
+//   - this.api                       (fetchInitialGraphRaw, transformToJIT,
+//                                     fetchNeighborhoodRaw, mergeRawGraph)
+//   - this.ht                        (loadJSON, refresh, graph.eachNode)
+//   - this.rawGraph                  (read+write)
+//   - this._initialParticipation     (write)
+//   - this.hashIndex                 (Map; cleared+repopulated)
+//   - this.likeManager               (nodeIdToChecksum256)
+//   - this.syncZoomSlider()          (sibling — stub)
+//   - this.updateHistoryCount()      (sibling — stub)
+//   - this.rebuildHashIndexFromRawGraph()  (intra-cluster — wire via compileMethod)
+//   - this._prePopulateDonutData()   (sibling, called from loadGraphData — stub
+//                                     to keep ht-graph-eachNode simulation small;
+//                                     its own behavior is not part of this cluster)
+// ---------------------------------------------------------------------------
+
+function makeStub({
+    initialGraphResponse,
+    neighborhoodResponse,
+    fetchInitialImpl,
+    fetchNeighborhoodImpl,
+    rawGraph = null,
+    hashIndex = new Map(),
+    checksumImpl,
+} = {}) {
+    const stub = {
+        rawGraph,
+        hashIndex,
+        _initialParticipation: undefined,
+        api: {
+            fetchInitialGraphRaw: fetchInitialImpl
+                ? jest.fn(fetchInitialImpl)
+                : jest.fn(async () => initialGraphResponse ?? { nodes: [], edges: [], participation: {} }),
+            fetchNeighborhoodRaw: fetchNeighborhoodImpl
+                ? jest.fn(fetchNeighborhoodImpl)
+                : jest.fn(async () => neighborhoodResponse ?? null),
+            transformToJIT: jest.fn(raw => ({ jitFor: raw })),
+            mergeRawGraph: jest.fn((a, b) => ({
+                nodes: [...(a?.nodes || []), ...(b?.nodes || [])],
+                edges: [...(a?.edges || []), ...(b?.edges || [])],
+            })),
+        },
+        ht: {
+            loadJSON: jest.fn(),
+            refresh: jest.fn(),
+            graph: { eachNode: jest.fn() },
+        },
+        likeManager: {
+            nodeIdToChecksum256: checksumImpl
+                ? jest.fn(checksumImpl)
+                : jest.fn(async (id) => `h(${id})`),
+        },
+        syncZoomSlider: jest.fn(),
+        updateHistoryCount: jest.fn(),
+        _prePopulateDonutData: jest.fn(),
+    };
+    // Intra-cluster delegation: loadGraphData → rebuildHashIndexFromRawGraph
+    // and ensureNodeInGraph → rebuildHashIndexFromRawGraph. Wire the real
+    // compiled body so we lock both in one shot.
+    stub.rebuildHashIndexFromRawGraph =
+        compileMethod('rebuildHashIndexFromRawGraph').bind(stub);
+    return stub;
+}
+
+// ---------------------------------------------------------------------------
+// Drift guard.
+// ---------------------------------------------------------------------------
+
+describe('Stage J.2 · GraphDataLoader · drift guard', () => {
+    test.each([
+        ['loadGraphData',                '()'],
+        ['rebuildHashIndexFromRawGraph', '()'],
+        ['ensureNodeInGraph',            '(nodeId)'],
+    ])('method %s exists with signature %s', (name, sig) => {
+        const expected = sig.slice(1, -1).split(',').map(s => s.trim()).filter(Boolean).join(', ');
+        const { params } = extractMethod(name);
+        const actual = params.split(',').map(s => s.trim()).filter(Boolean).join(', ');
+        expect(actual).toBe(expected);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// loadGraphData
+// ---------------------------------------------------------------------------
+
+describe('Stage J.2 · loadGraphData', () => {
+    test('happy path: stores rawGraph, captures participation, drives ht render', async () => {
+        const initialGraphResponse = {
+            nodes: [{ id: 'g:1', name: 'G1', type: 'group' }],
+            edges: [{ source: 'p:1', target: 'g:1', type: 'MEMBER_OF' }],
+            participation: { 'g:1': { totalTracks: 5, members: [] } },
+        };
+        const stub = makeStub({ initialGraphResponse });
+        await compileMethod('loadGraphData').call(stub);
+
+        expect(stub.rawGraph).toEqual({
+            nodes: initialGraphResponse.nodes,
+            edges: initialGraphResponse.edges,
+        });
+        expect(stub._initialParticipation).toEqual(initialGraphResponse.participation);
+        expect(stub.api.transformToJIT).toHaveBeenCalledWith(stub.rawGraph);
+        expect(stub.ht.loadJSON).toHaveBeenCalledTimes(1);
+        expect(stub.ht.refresh).toHaveBeenCalledTimes(1);
+        expect(stub.syncZoomSlider).toHaveBeenCalledTimes(1);
+        expect(stub.updateHistoryCount).toHaveBeenCalledTimes(1);
+        expect(stub._prePopulateDonutData).toHaveBeenCalledTimes(1);
+    });
+
+    test('rebuildHashIndexFromRawGraph runs after loadJSON/refresh', async () => {
+        const initialGraphResponse = {
+            nodes: [{ id: 'a' }, { id: 'b' }],
+            edges: [],
+            participation: {},
+        };
+        const stub = makeStub({ initialGraphResponse });
+        await compileMethod('loadGraphData').call(stub);
+
+        // Two nodes → likeManager called twice → hashIndex has two entries.
+        expect(stub.likeManager.nodeIdToChecksum256).toHaveBeenCalledTimes(2);
+        expect(stub.hashIndex.size).toBe(2);
+    });
+
+    test('missing participation field defaults to empty object', async () => {
+        const initialGraphResponse = { nodes: [], edges: [] };  // no participation
+        const stub = makeStub({ initialGraphResponse });
+        await compileMethod('loadGraphData').call(stub);
+        expect(stub._initialParticipation).toEqual({});
+    });
+
+    test('fetch failure is swallowed (logs and returns) — does not throw', async () => {
+        const stub = makeStub({
+            fetchInitialImpl: async () => { throw new Error('network down'); },
+        });
+        await expect(compileMethod('loadGraphData').call(stub)).resolves.toBeUndefined();
+        // None of the post-fetch side effects should have run.
+        expect(stub.ht.loadJSON).not.toHaveBeenCalled();
+        expect(stub.ht.refresh).not.toHaveBeenCalled();
+        expect(stub._prePopulateDonutData).not.toHaveBeenCalled();
+        expect(errSpy).toHaveBeenCalled();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// rebuildHashIndexFromRawGraph
+// ---------------------------------------------------------------------------
+
+describe('Stage J.2 · rebuildHashIndexFromRawGraph', () => {
+    test('builds Map<checksum256, {nodeId, name, type}> for every node', async () => {
+        const stub = makeStub({
+            rawGraph: {
+                nodes: [
+                    { id: 'g:beatles',  name: 'The Beatles', type: 'group'  },
+                    { id: 'p:lennon',   name: 'John Lennon', type: 'person' },
+                ],
+                edges: [],
+            },
+            hashIndex: new Map(),
+            checksumImpl: async (id) => `H_${id}`,
+        });
+
+        await compileMethod('rebuildHashIndexFromRawGraph').call(stub);
+
+        expect(stub.hashIndex.get('H_g:beatles')).toEqual({
+            nodeId: 'g:beatles', name: 'The Beatles', type: 'group',
+        });
+        expect(stub.hashIndex.get('H_p:lennon')).toEqual({
+            nodeId: 'p:lennon', name: 'John Lennon', type: 'person',
+        });
+    });
+
+    test('clears the existing hashIndex before repopulating', async () => {
+        const stale = new Map([['stale-hash', { nodeId: 'old', name: 'old', type: 'group' }]]);
+        const stub = makeStub({
+            rawGraph: { nodes: [{ id: 'fresh', name: 'F', type: 'group' }], edges: [] },
+            hashIndex: stale,
+        });
+
+        await compileMethod('rebuildHashIndexFromRawGraph').call(stub);
+
+        expect(stub.hashIndex.has('stale-hash')).toBe(false);
+        expect(stub.hashIndex.size).toBe(1);
+    });
+
+    test('early-returns when rawGraph.nodes is missing', async () => {
+        const stub = makeStub({ rawGraph: null });
+        await compileMethod('rebuildHashIndexFromRawGraph').call(stub);
+        expect(stub.likeManager.nodeIdToChecksum256).not.toHaveBeenCalled();
+    });
+
+    test('early-returns when likeManager is missing', async () => {
+        const stub = makeStub({ rawGraph: { nodes: [{ id: 'a' }], edges: [] } });
+        stub.likeManager = null;
+        const before = new Map(stub.hashIndex);
+        await compileMethod('rebuildHashIndexFromRawGraph').call(stub);
+        // hashIndex should be untouched (no clear, no populate)
+        expect([...stub.hashIndex.entries()]).toEqual([...before.entries()]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// ensureNodeInGraph
+// ---------------------------------------------------------------------------
+
+describe('Stage J.2 · ensureNodeInGraph', () => {
+    test('happy path: merges neighborhood, reloads JIT, rebuilds hashIndex', async () => {
+        const sub = {
+            nodes: [{ id: 'p:new', name: 'New Person', type: 'person' }],
+            edges: [{ source: 'p:new', target: 'g:1', type: 'MEMBER_OF' }],
+        };
+        const stub = makeStub({
+            rawGraph: { nodes: [{ id: 'g:1', name: 'G1', type: 'group' }], edges: [] },
+            neighborhoodResponse: sub,
+        });
+
+        await compileMethod('ensureNodeInGraph').call(stub, 'p:new');
+
+        expect(stub.api.fetchNeighborhoodRaw).toHaveBeenCalledWith('p:new');
+        expect(stub.api.mergeRawGraph).toHaveBeenCalledTimes(1);
+        // After merge, rawGraph should contain both the original and the new nodes.
+        expect(stub.rawGraph.nodes.map(n => n.id).sort()).toEqual(['g:1', 'p:new']);
+        expect(stub.api.transformToJIT).toHaveBeenCalledWith(stub.rawGraph);
+        expect(stub.ht.loadJSON).toHaveBeenCalledTimes(1);
+        expect(stub.ht.refresh).toHaveBeenCalledTimes(1);
+        // hashIndex was rebuilt for both merged nodes.
+        expect(stub.hashIndex.size).toBe(2);
+    });
+
+    test('null neighborhood response → early return, no merge, no render', async () => {
+        const stub = makeStub({
+            rawGraph: { nodes: [{ id: 'g:1' }], edges: [] },
+            neighborhoodResponse: null,
+        });
+
+        await compileMethod('ensureNodeInGraph').call(stub, 'missing-id');
+
+        expect(stub.api.mergeRawGraph).not.toHaveBeenCalled();
+        expect(stub.ht.loadJSON).not.toHaveBeenCalled();
+        expect(warnSpy).toHaveBeenCalled();
+    });
+
+    test('empty-nodes neighborhood → early return', async () => {
+        const stub = makeStub({
+            rawGraph: { nodes: [{ id: 'g:1' }], edges: [] },
+            neighborhoodResponse: { nodes: [], edges: [] },
+        });
+        await compileMethod('ensureNodeInGraph').call(stub, 'x');
+        expect(stub.api.mergeRawGraph).not.toHaveBeenCalled();
+        expect(stub.ht.loadJSON).not.toHaveBeenCalled();
+    });
+
+    test('graph > 500 nodes after merge → replaces rawGraph with neighborhood only', async () => {
+        const big = { nodes: Array.from({ length: 600 }, (_, i) => ({ id: `n:${i}` })), edges: [] };
+        const sub = { nodes: [{ id: 'fresh' }], edges: [] };
+        const stub = makeStub({
+            rawGraph: big,
+            neighborhoodResponse: sub,
+        });
+        // mergeRawGraph default impl concats arrays, so merged length = 601
+        await compileMethod('ensureNodeInGraph').call(stub, 'fresh');
+
+        // The 500-cap branch replaces rawGraph wholesale with `sub`.
+        expect(stub.rawGraph).toBe(sub);
+        expect(stub.rawGraph.nodes).toHaveLength(1);
+        expect(stub.api.transformToJIT).toHaveBeenCalledWith(sub);
+    });
+});

--- a/backend/test/visualization/overlayPositioner.snapshot.test.js
+++ b/backend/test/visualization/overlayPositioner.snapshot.test.js
@@ -1,0 +1,326 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Stage J.2 — OverlayPositioner characterization tests.
+ *
+ * The handoff flagged OverlayPositioner as the smallest of the three
+ * deferred Stage-J extractions: ReleaseOrbitOverlay is already its own
+ * class, so what's left in MusicGraph is the *positioning glue* that
+ * computes screen coords + visual-radius from a JIT node and forwards
+ * to overlay.show / .updatePosition. The two methods that own this
+ * glue (currently lines ~1169–1219 of MusicGraph.js) duplicate the
+ * radius computation — extraction-bait that we must lock first.
+ *
+ * Methods covered:
+ *   _syncReleaseOverlay(node)   — show on group nodes, hide otherwise
+ *   _updateOverlayPosition()    — re-anchor after re-render
+ *
+ * Strategy: same source-extract + isolated-invoke pattern as the
+ * Stage H InfoPanelRenderer test. We stub `_getNodeScreenPos` (canvas-
+ * dependent and not part of the cluster being extracted) so the tests
+ * focus on the radius math and the call structure, which are what the
+ * extracted module will own.
+ */
+
+import { jest } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import { parse } from '@babel/parser';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const MUSIC_GRAPH_PATH = resolve(__dirname, '../../../frontend/src/visualization/MusicGraph.js');
+const SOURCE = readFileSync(MUSIC_GRAPH_PATH, 'utf8');
+
+// ---------------------------------------------------------------------------
+// AST extraction.
+// ---------------------------------------------------------------------------
+
+const AST = parse(SOURCE, { sourceType: 'module', plugins: ['classProperties'] });
+
+const METHOD_INDEX = (() => {
+    const map = new Map();
+    function visit(node) {
+        if (!node || typeof node !== 'object') return;
+        if (node.type === 'ClassMethod' && node.key?.type === 'Identifier') {
+            map.set(node.key.name, node);
+        }
+        for (const key of Object.keys(node)) {
+            const v = node[key];
+            if (Array.isArray(v)) v.forEach(visit);
+            else if (v && typeof v === 'object' && v.type) visit(v);
+        }
+    }
+    visit(AST);
+    return map;
+})();
+
+function extractMethod(name) {
+    const node = METHOD_INDEX.get(name);
+    if (!node) throw new Error(`extractMethod: ${name} not found in MusicGraph.js`);
+    const params = node.params.map(p => SOURCE.slice(p.start, p.end)).join(', ');
+    const body = SOURCE.slice(node.body.start + 1, node.body.end - 1);
+    const isAsync = !!node.async;
+    return { params, body, isAsync };
+}
+
+function compileMethod(name) {
+    const { params, body, isAsync } = extractMethod(name);
+    const argNames = params.split(',').map(s => s.trim()).filter(Boolean);
+    if (isAsync) {
+        const AsyncFunction = (async function () {}).constructor;
+        return new AsyncFunction(...argNames, body);
+    }
+    // eslint-disable-next-line no-new-func
+    return new Function(...argNames, body);
+}
+
+// ---------------------------------------------------------------------------
+// JIT node fixture. The methods read:
+//   node.data.type            (string)
+//   node.data.group_id        (string, may be undefined)
+//   node.id                   (string, fallback when group_id missing)
+//   node.getData('donutSlices')  (array | null | undefined)
+// ---------------------------------------------------------------------------
+
+function makeNode({ id = 'node-id', type = 'group', group_id, donutSlices } = {}) {
+    return {
+        id,
+        data: { type, group_id },
+        getData: jest.fn(key => (key === 'donutSlices' ? donutSlices : undefined)),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Stub `this`. The methods reach into:
+//   - this.releaseOverlay         (.show, .hide, .updatePosition, .visible)
+//   - this.selectedNode           (used by _updateOverlayPosition)
+//   - this._getNodeScreenPos(node) (returns {x, y, dim})
+//   - document.getElementById('viz-container')   (for getBoundingClientRect)
+// ---------------------------------------------------------------------------
+
+function setupVizContainer({ left = 100, top = 50 } = {}) {
+    document.body.innerHTML = '';
+    const div = document.createElement('div');
+    div.id = 'viz-container';
+    document.body.appendChild(div);
+    // jsdom getBoundingClientRect returns zeros — patch the prototype
+    // for our fixture container so subtracting works deterministically.
+    div.getBoundingClientRect = () => ({ left, top, right: 0, bottom: 0, width: 0, height: 0 });
+    return div;
+}
+
+afterEach(() => { document.body.innerHTML = ''; });
+
+function makeStub({
+    overlayVisible = false,
+    selectedNode = null,
+    screenPosImpl,
+} = {}) {
+    return {
+        selectedNode,
+        releaseOverlay: {
+            visible: overlayVisible,
+            show: jest.fn(async () => {}),
+            hide: jest.fn(),
+            updatePosition: jest.fn(),
+        },
+        _getNodeScreenPos: screenPosImpl
+            ? jest.fn(screenPosImpl)
+            : jest.fn(() => ({ x: 200, y: 150, dim: 30 })),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Drift guard.
+// ---------------------------------------------------------------------------
+
+describe('Stage J.2 · OverlayPositioner · drift guard', () => {
+    test.each([
+        ['_syncReleaseOverlay',   '(node)'],
+        ['_updateOverlayPosition', '()'],
+    ])('method %s exists with signature %s', (name, sig) => {
+        const expected = sig.slice(1, -1).split(',').map(s => s.trim()).filter(Boolean).join(', ');
+        const { params } = extractMethod(name);
+        const actual = params.split(',').map(s => s.trim()).filter(Boolean).join(', ');
+        expect(actual).toBe(expected);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// _syncReleaseOverlay
+// ---------------------------------------------------------------------------
+
+describe('Stage J.2 · _syncReleaseOverlay', () => {
+    test('non-group node → hide(), no show()', async () => {
+        setupVizContainer();
+        const stub = makeStub();
+        await compileMethod('_syncReleaseOverlay').call(stub, makeNode({ type: 'person' }));
+        expect(stub.releaseOverlay.hide).toHaveBeenCalledTimes(1);
+        expect(stub.releaseOverlay.show).not.toHaveBeenCalled();
+    });
+
+    test('group node without donut slices → show() with bare dim as visualRadius', async () => {
+        setupVizContainer({ left: 100, top: 50 });
+        const stub = makeStub({
+            screenPosImpl: () => ({ x: 200, y: 150, dim: 30 }),
+        });
+        await compileMethod('_syncReleaseOverlay').call(stub, makeNode({
+            type: 'group', group_id: 'group:beatles', donutSlices: null,
+        }));
+
+        // relX = 200 - 100, relY = 150 - 50, visualRadius = dim = 30
+        expect(stub.releaseOverlay.show).toHaveBeenCalledWith(
+            'group:beatles',
+            { x: 100, y: 100 },
+            30
+        );
+    });
+
+    test('group node with donut slices → visualRadius = dim + gap + thickness', async () => {
+        setupVizContainer({ left: 0, top: 0 });
+        const stub = makeStub({
+            screenPosImpl: () => ({ x: 0, y: 0, dim: 100 }),
+        });
+        await compileMethod('_syncReleaseOverlay').call(stub, makeNode({
+            type: 'group', group_id: 'g:1', donutSlices: [{ pct: 1.0 }],
+        }));
+
+        // dim=100 → gap = max(2, 100*0.20) = 20, thickness = max(3, 100*0.45) = 45
+        // visualRadius = 100 + 20 + 45 = 165
+        expect(stub.releaseOverlay.show).toHaveBeenCalledWith(
+            'g:1',
+            { x: 0, y: 0 },
+            165
+        );
+    });
+
+    test('small dim with donut slices → gap and thickness floor at 2 and 3', async () => {
+        setupVizContainer({ left: 0, top: 0 });
+        const stub = makeStub({
+            screenPosImpl: () => ({ x: 0, y: 0, dim: 5 }),
+        });
+        await compileMethod('_syncReleaseOverlay').call(stub, makeNode({
+            type: 'group', group_id: 'g:tiny', donutSlices: [{ pct: 1.0 }],
+        }));
+
+        // dim=5 → gap = max(2, 5*0.20=1) = 2, thickness = max(3, 5*0.45=2.25) = 3
+        // visualRadius = 5 + 2 + 3 = 10
+        expect(stub.releaseOverlay.show).toHaveBeenCalledWith(
+            'g:tiny',
+            { x: 0, y: 0 },
+            10
+        );
+    });
+
+    test('group node falls back to node.id when group_id is missing', async () => {
+        setupVizContainer();
+        const stub = makeStub();
+        await compileMethod('_syncReleaseOverlay').call(stub, makeNode({
+            id: 'fallback:id', type: 'group', group_id: undefined,
+        }));
+        expect(stub.releaseOverlay.show).toHaveBeenCalledWith(
+            'fallback:id',
+            expect.any(Object),
+            expect.any(Number)
+        );
+    });
+
+    test('missing #viz-container → coords default to (x, y), unshifted', async () => {
+        document.body.innerHTML = '';  // no container
+        const stub = makeStub({
+            screenPosImpl: () => ({ x: 333, y: 444, dim: 10 }),
+        });
+        await compileMethod('_syncReleaseOverlay').call(stub, makeNode({
+            type: 'group', group_id: 'g',
+        }));
+        expect(stub.releaseOverlay.show).toHaveBeenCalledWith(
+            'g',
+            { x: 333, y: 444 },  // {left:0, top:0} fallback applied
+            10
+        );
+    });
+
+    test('case-insensitive type check: "GROUP" still matches group branch', async () => {
+        setupVizContainer();
+        const stub = makeStub();
+        await compileMethod('_syncReleaseOverlay').call(stub, makeNode({
+            type: 'GROUP', group_id: 'g',
+        }));
+        expect(stub.releaseOverlay.hide).not.toHaveBeenCalled();
+        expect(stub.releaseOverlay.show).toHaveBeenCalled();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// _updateOverlayPosition
+// ---------------------------------------------------------------------------
+
+describe('Stage J.2 · _updateOverlayPosition', () => {
+    test('overlay not visible → early return, no updatePosition()', () => {
+        setupVizContainer();
+        const stub = makeStub({ overlayVisible: false, selectedNode: makeNode() });
+        compileMethod('_updateOverlayPosition').call(stub);
+        expect(stub.releaseOverlay.updatePosition).not.toHaveBeenCalled();
+    });
+
+    test('selectedNode null → early return, no updatePosition()', () => {
+        setupVizContainer();
+        const stub = makeStub({ overlayVisible: true, selectedNode: null });
+        compileMethod('_updateOverlayPosition').call(stub);
+        expect(stub.releaseOverlay.updatePosition).not.toHaveBeenCalled();
+    });
+
+    test('happy path without slices → updatePosition with bare dim', () => {
+        setupVizContainer({ left: 10, top: 20 });
+        const stub = makeStub({
+            overlayVisible: true,
+            selectedNode: makeNode({ donutSlices: null }),
+            screenPosImpl: () => ({ x: 110, y: 120, dim: 40 }),
+        });
+        compileMethod('_updateOverlayPosition').call(stub);
+        expect(stub.releaseOverlay.updatePosition).toHaveBeenCalledWith(
+            { x: 100, y: 100 },
+            40
+        );
+    });
+
+    test('happy path with slices → updatePosition with dim + gap + thickness', () => {
+        setupVizContainer({ left: 0, top: 0 });
+        const stub = makeStub({
+            overlayVisible: true,
+            selectedNode: makeNode({ donutSlices: [{ pct: 1.0 }] }),
+            screenPosImpl: () => ({ x: 0, y: 0, dim: 50 }),
+        });
+        compileMethod('_updateOverlayPosition').call(stub);
+        // gap = max(2, 50*0.20=10) = 10, thickness = max(3, 50*0.45=22.5) = 22.5
+        // visualRadius = 50 + 10 + 22.5 = 82.5
+        expect(stub.releaseOverlay.updatePosition).toHaveBeenCalledWith(
+            { x: 0, y: 0 },
+            82.5
+        );
+    });
+
+    test('radius computation matches _syncReleaseOverlay (regression guard for the duplication)', async () => {
+        setupVizContainer({ left: 0, top: 0 });
+
+        const node = makeNode({ type: 'group', group_id: 'g', donutSlices: [{ pct: 1.0 }] });
+        const screenPos = () => ({ x: 0, y: 0, dim: 75 });
+
+        const syncStub = makeStub({ screenPosImpl: screenPos });
+        await compileMethod('_syncReleaseOverlay').call(syncStub, node);
+
+        const updateStub = makeStub({
+            overlayVisible: true, selectedNode: node, screenPosImpl: screenPos,
+        });
+        compileMethod('_updateOverlayPosition').call(updateStub);
+
+        // Same node + same dim must produce the same visualRadius in both
+        // call paths. If a future extraction de-duplicates the math, this
+        // test will keep both branches honest.
+        const showRadius   = syncStub.releaseOverlay.show.mock.calls[0][2];
+        const updateRadius = updateStub.releaseOverlay.updatePosition.mock.calls[0][1];
+        expect(showRadius).toBe(updateRadius);
+    });
+});


### PR DESCRIPTION
Locks the behaviour of three method clusters on MusicGraph that the Stage J handoff identified as next-up extractions but deferred for lack of regression coverage:

- FavoritesManager  (~150 lines, lines 1735–1803 of MusicGraph.js)
- GraphDataLoader   (~80  lines, lines 1425–1499 + 2016–2035)
- OverlayPositioner (~50  lines, lines 1169–1219)

Same source-extract + isolated-invoke pattern as Stage H's InfoPanelRenderer test: read MusicGraph.js as text, AST-parse to locate each method, slice the body, compile via `new Function`, and invoke with `Function.prototype.call(stubThis, ...)` under jsdom. Re-reading the live source every run means any drift inside the method bodies surfaces as a snapshot or assertion diff.

What each file covers:

  favoritesManager.snapshot.test.js — 21 tests / 5 HTML snapshots
    - drift guard for the four method signatures
    - updateFavoritesCount: writes Set size to #favorites-count, no-op when element missing
    - refreshFavoritesFromChain: replaces Set, sets Loaded flag, calls fetchAccountLikes(200), updates count
    - toggleFavoritesPanel: open/close branches, render-on-open only
    - renderFavoritesPanel: 4 branches snapshotted (not connected, empty rows, hashIndex hit, hashIndex miss with truncated id) + click-handler wiring for resolved vs unresolved rows + fetch failure message + missing-element no-op

  graphDataLoader.snapshot.test.js — 15 tests
    - drift guard for the three method signatures
    - loadGraphData: rawGraph shape, _initialParticipation default, ht.loadJSON/refresh/updateHistoryCount/syncZoomSlider call order, hash-index rebuilt from new nodes, swallowed-fetch-error branch
    - rebuildHashIndexFromRawGraph: Map population shape, clear-before- populate, early returns on missing rawGraph and missing likeManager
    - ensureNodeInGraph: merge + reload happy path, null/empty neighborhood early returns, the >500-node-cap branch that replaces rawGraph with the neighborhood subgraph

  overlayPositioner.snapshot.test.js — 14 tests
    - drift guard for the two method signatures
    - _syncReleaseOverlay: non-group hide branch, group show branch with bare dim vs with donut slices (radius = dim+gap+thickness), gap/thickness floor at 2/3 for tiny dim, group_id → node.id fallback, missing #viz-container → unshifted coords, case- insensitive type check
    - _updateOverlayPosition: the two early-return branches (overlay !visible, selectedNode null) and the two compute paths (with/without donut slices)
    - Cross-method regression guard asserting both methods compute the same visualRadius for the same input — locks the duplicated math the upcoming extraction will deduplicate

Verified: full backend suite 534 passed / 218 skipped / 35 snapshots matched (was 484 / 218 / 30; +50 tests = 21 + 15 + 14, +5 snapshots all from FavoritesManager renderPanel). Zero regressions.

These tests are the safety net for Stage J.2's actual extractions: once they pass against the post-extraction renderer/loader/positioner modules without touching the snapshots, behaviour is preserved.

https://claude.ai/code/session_01D7qa8hTDkDUKjew7Hmau9d