### PR TITLE
Make SBOM generation non-blocking in Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -73,7 +73,15 @@ jobs:
           VCS_REF=${{ github.sha }}
           VERSION=${{ steps.meta.outputs.version }}
 
+    # SBOM generation is an audit artifact, not a build gate. The action
+    # downloads Syft from github.com/anchore/syft/releases on every run,
+    # which is occasionally rate-limited or 502s. A flaky failure here
+    # would otherwise block both the image push (this job) and the Trivy
+    # security scan (needs: build-and-push). Failure surfaces as a yellow
+    # warning in the run; the next successful push regenerates the SBOM.
     - name: Generate SBOM
+      id: sbom
+      continue-on-error: true
       uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
       with:
         # Use the exact tag produced by docker/metadata-action (already lowercased/valid)
@@ -83,6 +91,7 @@ jobs:
 
 
     - name: Upload SBOM
+      if: steps.sbom.outcome == 'success'
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: sbom-${{ matrix.component }}


### PR DESCRIPTION
## Summary
Modified the Docker publish workflow to make SBOM generation a non-blocking step. This prevents flaky failures in the Syft action from blocking image pushes and downstream security scans.

## Key Changes
- Added `continue-on-error: true` to the "Generate SBOM" step to allow the workflow to continue even if SBOM generation fails
- Added step ID (`id: sbom`) to the "Generate SBOM" step to track its outcome
- Added conditional check (`if: steps.sbom.outcome == 'success'`) to the "Upload SBOM" step to only upload artifacts when SBOM generation succeeds
- Added explanatory comment documenting why SBOM generation failures should not block the workflow

## Implementation Details
The Syft action occasionally experiences rate-limiting or transient failures when downloading from GitHub releases. Since SBOM generation is an audit artifact rather than a build requirement, these failures should not prevent:
1. The Docker image from being pushed (current job)
2. The Trivy security scan from running (downstream job with `needs: build-and-push`)

With these changes, SBOM generation failures will surface as yellow warnings in the workflow run, and the SBOM will be regenerated on the next successful push.

https://claude.ai/code/session_013ya9NZB4C9fESFwAiSi9DF