### PR TITLE
Replace innerHTML patterns with DOM construction in InfoPanelRenderer

### DIFF
--- a/backend/test/visualization/__snapshots__/musicGraphRenders.snapshot.test.js.snap
+++ b/backend/test/visualization/__snapshots__/musicGraphRenders.snapshot.test.js.snap
@@ -9,95 +9,18 @@ exports[`Stage H · _renderClaimDetail add_claim with object value and url sourc
 
 exports[`Stage H · _renderClaimDetail edit_claim with primitive value and string source: edit-claim-primitive 1`] = `"<div class="curate-section"><h4>Edit Claim</h4><div class="curate-field"><span class="curate-field-label">Target Type</span><span class="curate-field-value">Track</span></div><div class="curate-field"><span class="curate-field-label">Target ID</span><span class="curate-field-value">track:abbey</span></div><div class="curate-field"><span class="curate-field-label">Field</span><span class="curate-field-value">duration</span></div><div class="curate-field"><span class="curate-field-label">Value</span><span class="curate-field-value">259</span></div><div class="curate-field"><span class="curate-field-label">Source</span><span class="curate-field-value">liner notes</span></div></div>"`;
 
-exports[`Stage H · _renderCurateDetail add_claim detail (finalized) suppresses vote buttons: add-claim-finalized 1`] = `
-"<div class="curate-detail-header">
-            <h3>ADD_CLAIM</h3>
-            <div class="curate-detail-meta">
-                <span>by eve</span>
-                <span>LOCALE_DATETIME(2026-05-05T00:00:00.000Z)</span>
-                <span>Finalized</span>
-            </div>
-        </div><div class="curate-detail-voting">
-            <span class="curate-score curate-score--positive">
-                +4
-            </span>
-            <span class="curate-voters">
-                <span class="curate-up">5 (3)</span> /
-                <span class="curate-down">1 (1)</span>
-            </span>
-        </div><div class="curate-detail-body"><div class="curate-section"><h4>Add Claim</h4><div class="curate-field"><span class="curate-field-label">Target Type</span><span class="curate-field-value">Person</span></div><div class="curate-field"><span class="curate-field-label">Target ID</span><span class="curate-field-value">person:lennon</span></div><div class="curate-field"><span class="curate-field-label">Field</span><span class="curate-field-value">bio</span></div><div class="curate-field"><span class="curate-field-label">Value</span><span class="curate-field-value">Songwriter and rhythm guitarist</span></div></div></div>"
-`;
+exports[`Stage H · _renderCurateDetail add_claim detail (finalized) suppresses vote buttons: add-claim-finalized 1`] = `"<div class="curate-detail-header"><h3>ADD_CLAIM</h3><div class="curate-detail-meta"><span>by eve</span><span>LOCALE_DATETIME(2026-05-05T00:00:00.000Z)</span><span>Finalized</span></div></div><div class="curate-detail-voting"><span class="curate-score curate-score--positive">+4</span><span class="curate-voters"><span class="curate-up">5 (3)</span> / <span class="curate-down">1 (1)</span></span></div><div class="curate-detail-body"><div class="curate-section"><h4>Add Claim</h4><div class="curate-field"><span class="curate-field-label">Target Type</span><span class="curate-field-value">Person</span></div><div class="curate-field"><span class="curate-field-label">Target ID</span><span class="curate-field-value">person:lennon</span></div><div class="curate-field"><span class="curate-field-label">Field</span><span class="curate-field-value">bio</span></div><div class="curate-field"><span class="curate-field-label">Value</span><span class="curate-field-value">Songwriter and rhythm guitarist</span></div></div></div>"`;
 
 exports[`Stage H · _renderCurateDetail release_bundle detail (open) with raw event JSON: release-bundle-open 1`] = `
-"<div class="curate-detail-header">
-            <h3>CREATE_RELEASE_BUNDLE</h3>
-            <div class="curate-detail-meta">
-                <span>by alice</span>
-                <span>LOCALE_DATETIME(2026-05-05T00:00:00.000Z)</span>
-                <span>Open</span>
-            </div>
-        </div><div class="curate-detail-voting">
-            <span class="curate-score curate-score--positive">
-                +2
-            </span>
-            <span class="curate-voters">
-                <span class="curate-up">2 (1)</span> /
-                <span class="curate-down">0 (0)</span>
-            </span>
-        <button class="curate-vote-btn curate-vote-up">Upvote</button><button class="curate-vote-btn curate-vote-down">Downvote</button></div><div class="curate-detail-body"><div class="curate-section"><h4>Release</h4><div class="curate-field"><span class="curate-field-label">Name</span><span class="curate-field-value">Abbey Road</span></div><div class="curate-field"><span class="curate-field-label">Date</span><span class="curate-field-value">1969-09-26</span></div><div class="curate-field"><span class="curate-field-label">Format</span><span class="curate-field-value">LP</span></div></div><div class="curate-raw-json">
-                <details>
-                    <summary>Raw Event JSON</summary>
-                    <pre>{
+"<div class="curate-detail-header"><h3>CREATE_RELEASE_BUNDLE</h3><div class="curate-detail-meta"><span>by alice</span><span>LOCALE_DATETIME(2026-05-05T00:00:00.000Z)</span><span>Open</span></div></div><div class="curate-detail-voting"><span class="curate-score curate-score--positive">+2</span><span class="curate-voters"><span class="curate-up">2 (1)</span> / <span class="curate-down">0 (0)</span></span><button class="curate-vote-btn curate-vote-up">Upvote</button><button class="curate-vote-btn curate-vote-down">Downvote</button></div><div class="curate-detail-body"><div class="curate-section"><h4>Release</h4><div class="curate-field"><span class="curate-field-label">Name</span><span class="curate-field-value">Abbey Road</span></div><div class="curate-field"><span class="curate-field-label">Date</span><span class="curate-field-value">1969-09-26</span></div><div class="curate-field"><span class="curate-field-label">Format</span><span class="curate-field-value">LP</span></div></div><div class="curate-raw-json"><details><summary>Raw Event JSON</summary><pre>{
   "v": 1,
   "type": "CREATE_RELEASE_BUNDLE"
-}</pre>
-                </details>
-            </div></div>"
+}</pre></details></div></div>"
 `;
 
-exports[`Stage H · _renderCurateRow finalized vote row with no event_summary (uses hash prefix): finalized-vote-negative 1`] = `
-"<div class="curate-row" data-hash="fedcba9876543210">
-            <div class="curate-row__header">
-                <span class="curate-type-badge curate-type-40">Vote</span>
-                <span class="curate-row__title">fedcba987654...</span>
-                <span class="curate-row__time"></span>
-            </div>
-            <div class="curate-row__author">by bob</div>
-            <div class="curate-row__tally">
-                <span class="curate-score curate-score--negative">
-                    -3
-                </span>
-                <span class="curate-voters">
-                    <span class="curate-up">1 (1)</span>
-                    /
-                    <span class="curate-down">4 (2)</span>
-                </span>
-                <span class="curate-status curate-status--finalized">Finalized</span>
-            </div>
-        </div>"
-`;
+exports[`Stage H · _renderCurateRow finalized vote row with no event_summary (uses hash prefix): finalized-vote-negative 1`] = `"<div class="curate-row" data-hash="fedcba9876543210"><div class="curate-row__header"><span class="curate-type-badge curate-type-40">Vote</span><span class="curate-row__title">fedcba987654...</span><span class="curate-row__time"></span></div><div class="curate-row__author">by bob</div><div class="curate-row__tally"><span class="curate-score curate-score--negative">-3</span><span class="curate-voters"><span class="curate-up">1 (1)</span> / <span class="curate-down">4 (2)</span></span><span class="curate-status curate-status--finalized">Finalized</span></div></div>"`;
 
-exports[`Stage H · _renderCurateRow open release row with positive net score: open-release-positive 1`] = `
-"<div class="curate-row" data-hash="abcdef0123456789">
-            <div class="curate-row__header">
-                <span class="curate-type-badge curate-type-21">Release</span>
-                <span class="curate-row__title">Abbey Road</span>
-                <span class="curate-row__time">LOCALE_DATE(2026-05-05)</span>
-            </div>
-            <div class="curate-row__author">by alice</div>
-            <div class="curate-row__tally">
-                <span class="curate-score curate-score--positive">
-                    +5
-                </span>
-                <span class="curate-voters">
-                    <span class="curate-up">7 (3)</span>
-                    /
-                    <span class="curate-down">2 (1)</span>
-                </span>
-                <span class="curate-status ">Open</span>
-            </div>
-        </div>"
-`;
+exports[`Stage H · _renderCurateRow open release row with positive net score: open-release-positive 1`] = `"<div class="curate-row" data-hash="abcdef0123456789"><div class="curate-row__header"><span class="curate-type-badge curate-type-21">Release</span><span class="curate-row__title">Abbey Road</span><span class="curate-row__time">LOCALE_DATE(2026-05-05)</span></div><div class="curate-row__author">by alice</div><div class="curate-row__tally"><span class="curate-score curate-score--positive">+5</span><span class="curate-voters"><span class="curate-up">7 (3)</span> / <span class="curate-down">2 (1)</span></span><span class="curate-status">Open</span></div></div>"`;
 
 exports[`Stage H · _renderReleaseBundleDetail full release bundle with two groups, tracks, songs, and sources: release-bundle-full 1`] = `"<div class="curate-section"><h4>Release</h4><div class="curate-field"><span class="curate-field-label">Name</span><span class="curate-field-value">Abbey Road</span></div><div class="curate-field"><span class="curate-field-label">Date</span><span class="curate-field-value">1969-09-26</span></div><div class="curate-field"><span class="curate-field-label">Format</span><span class="curate-field-value">LP</span></div><div class="curate-field"><span class="curate-field-label">Alt Names</span><span class="curate-field-value">Abbey Rd.</span></div><div class="curate-field"><span class="curate-field-label">Master ID</span><span class="curate-field-value">master:abbey</span></div></div><div class="curate-section"><h4>Labels</h4><div class="curate-field-value">Apple Records <span style="color:#666">(label:apple)</span></div></div><div class="curate-section"><h4>Groups</h4><div class="curate-field-value" style="margin-bottom:6px"><strong>The Beatles</strong> <span style="color:#666">(group:beatles)</span></div><div class="curate-person-list"><span class="curate-person-chip">John Lennon <span class="curate-role">rhythm guitar, vocals</span></span><span class="curate-person-chip">Paul McCartney <span class="curate-role">bass, vocals</span></span></div><div class="curate-field-value" style="margin-bottom:6px"><strong>Sessioneers</strong></div></div><div class="curate-section"><h4>Release Personnel</h4><div class="curate-person-list"><span class="curate-person-chip">Billy Preston <span class="curate-role">organ</span></span></div></div><div class="curate-section"><h4>Tracks</h4><div class="curate-track-item"><div class="curate-track-title">1. Come Together <span style="color:#666;font-size:10px">track:abbey-1</span></div><div class="curate-track-credits">Group: The Beatles (John Lennon, Paul McCartney)</div><div class="curate-track-credits">Guests: Billy Preston (organ)</div><div class="curate-track-credits">Producers: George Martin</div><div class="curate-track-credits">Listen: <a href="https://example.com/come-together" target="_blank" style="color:#5c9cef">example.com</a></div></div><div class="curate-track-item"><div class="curate-track-title">2. Something <span style="color:#666;font-size:10px">track:abbey-2</span></div><div class="curate-track-credits">Samples: track:earlier</div></div></div><div class="curate-section"><h4>Songs (Compositions)</h4><div class="curate-field-value" style="margin-bottom:4px">Come Together — John Lennon, Paul McCartney</div><div class="curate-field-value" style="margin-bottom:4px">Something — George Harrison</div></div><div class="curate-section"><h4>Sources</h4><div class="curate-field-value"><a href="https://discogs.com/release/12345" target="_blank" style="color:#5c9cef">https://discogs.com/release/12345</a></div></div>"`;
 

--- a/backend/test/visualization/musicGraphRenders.snapshot.test.js
+++ b/backend/test/visualization/musicGraphRenders.snapshot.test.js
@@ -90,14 +90,9 @@ function makeStubThis() {
         div.textContent = str;
         return div.innerHTML;
     };
-    const detailFieldImpl = function (label, value) {
-        if (!value) return '';
-        return `<div class="curate-field"><span class="curate-field-label">${escapeImpl(label)}</span><span class="curate-field-value">${escapeImpl(String(value))}</span></div>`;
-    };
     const stub = {
         // Helpers — now public methods on InfoPanelRenderer.
         escapeHtml: escapeImpl,
-        detailField: detailFieldImpl,
         // Nav/vote handlers were `this._foo` on MusicGraph; in the renderer
         // they live behind a `callbacks` indirection so the module has no
         // implicit coupling to MusicGraph beyond this object.
@@ -108,6 +103,12 @@ function makeStubThis() {
             voteFromDetail: jest.fn(),
         },
     };
+    // PR-L: methods now build DOM via the `_el` helper and call
+    // `this.detailField(...)` which returns an Element (was a string).
+    // Compile both from the live source so changes to either flow into
+    // the assertion layer.
+    stub._el = compileMethod('_el').bind(stub);
+    stub.detailField = compileMethod('detailField').bind(stub);
     // The two delegating methods need real impls so renderCurateDetail can
     // invoke them through `this`.
     stub.renderReleaseBundleDetail = compileMethod('renderReleaseBundleDetail').bind(stub);

--- a/frontend/src/visualization/InfoPanelRenderer.js
+++ b/frontend/src/visualization/InfoPanelRenderer.js
@@ -2,11 +2,22 @@
  * InfoPanelRenderer — DOM rendering for the info panel sections that were
  * previously private methods on MusicGraph (the 2,562-line god class).
  *
- * Each method writes HTML into a caller-provided container element. The
+ * Each method writes content into a caller-provided container element. The
  * renderer is dependency-injected with the small set of MusicGraph callbacks
  * its handlers need (graph navigation, release navigation, curate row
  * selection, voting), so the module has no implicit `this` coupling to
  * MusicGraph beyond the explicit `callbacks` object.
+ *
+ * Stage L (PR-L): all `innerHTML += <template literal>` patterns have been
+ * replaced with explicit DOM construction via the `_el` helper. User-supplied
+ * values now flow through `Text` nodes (auto-escaped by the browser) instead
+ * of being interpolated into HTML strings, removing the implicit XSS surface
+ * that lived in every escapeHtml call site. The snapshot suite at
+ * `backend/test/visualization/musicGraphRenders.snapshot.test.js` locks the
+ * serialized output. The previous template-literal whitespace text nodes
+ * (between sibling block elements) are gone — semantically identical, byte-
+ * different. Snapshots updated in the same PR; reviewed for whitespace-only
+ * drift.
  *
  * Public API:
  *   renderSongDetails(song, titleElement, contentElement)
@@ -14,12 +25,10 @@
  *   renderCurateDetail(container, resp, op)
  *   renderReleaseBundleDetail(container, detail)
  *   renderClaimDetail(container, detail)
- *   escapeHtml(str)                                 → string
- *   detailField(label, value)                       → string (HTML)
- *
- * Snapshot contract: the HTML produced by these methods is locked by
- * `backend/test/visualization/musicGraphRenders.snapshot.test.js`. If you
- * change the markup, snapshots will diff — investigate before updating.
+ *   detailField(label, value)                       → HTMLElement | null
+ *   escapeHtml(str)                                 → string  (legacy, retained
+ *                                                    for any external caller; no
+ *                                                    longer used internally)
  *
  * @module visualization/InfoPanelRenderer
  */
@@ -40,51 +49,117 @@ export class InfoPanelRenderer {
     }
 
     /**
+     * DOM-builder helper. Builds a single element with attributes and
+     * children in one call.
+     *
+     *   _el('div', {className: 'foo'}, 'hello', _el('span', null, 'world'))
+     *
+     * Attribute keys:
+     *   - 'className'                      → assigned to el.className
+     *   - 'style'   (string)               → setAttribute('style', value).
+     *                                        Strings are preferred over objects
+     *                                        because jsdom normalizes any value
+     *                                        set through el.style.* (e.g.,
+     *                                        '#666' → 'rgb(102, 102, 102)') and
+     *                                        we want byte-stable snapshots.
+     *   - 'dataset' (object)               → Object.assign(el.dataset, value)
+     *   - 'onClick' (function)             → addEventListener('click', value)
+     *   - everything else                  → setAttribute(key, value)
+     *   - value === false / null / undefined → attribute skipped
+     *
+     * Children:
+     *   - strings / numbers → wrapped in a Text node (auto-escapes)
+     *   - Element / DocumentFragment → appended as-is
+     *   - false / null / undefined  → skipped (so conditional children
+     *     can be inlined: `cond && _el(...)`)
+     *   - arrays are flattened
+     */
+    _el(tag, attrs, ...children) {
+        const el = document.createElement(tag);
+        if (attrs) {
+            for (const [key, value] of Object.entries(attrs)) {
+                if (value == null || value === false) continue;
+                if (key === 'className') {
+                    el.className = value;
+                } else if (key === 'dataset' && typeof value === 'object') {
+                    Object.assign(el.dataset, value);
+                } else if (key.startsWith('on') && typeof value === 'function') {
+                    el.addEventListener(key.slice(2).toLowerCase(), value);
+                } else {
+                    el.setAttribute(key, value);
+                }
+            }
+        }
+        for (const child of children.flat()) {
+            if (child == null || child === false) continue;
+            if (typeof child === 'string' || typeof child === 'number') {
+                el.appendChild(document.createTextNode(String(child)));
+            } else {
+                el.appendChild(child);
+            }
+        }
+        return el;
+    }
+
+    /**
      * Render song details in the info panel.
      * Shows songwriters, lyrics, and clickable releases.
      */
     renderSongDetails(song, titleElement, contentElement) {
-        const esc = v => String(v ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
         titleElement.textContent = song.title || song.name || 'Unknown Song';
+        contentElement.replaceChildren();
 
-        let html = '';
-        html += `<p class="info-meta"><strong>Type:</strong> Song (Composition)</p>`;
+        contentElement.appendChild(
+            this._el('p', { className: 'info-meta' },
+                this._el('strong', null, 'Type:'), ' Song (Composition)'));
 
-        // Songwriters
         const writers = song.writers || [];
         if (writers.length > 0) {
-            html += `<div class="info-section"><h4>Songwriters</h4><ul class="info-list">`;
-            writers.forEach(w => {
-                const nameHtml = w.person_id
-                    ? `<a href="#" class="info-nav-link" data-node-id="${esc(w.person_id)}">${esc(w.writer)}</a>`
-                    : esc(w.writer);
-                html += `<li>${nameHtml}</li>`;
-            });
-            html += `</ul></div>`;
+            const ul = this._el('ul', { className: 'info-list' });
+            for (const w of writers) {
+                const inner = w.person_id
+                    ? this._el('a', {
+                        href: '#',
+                        className: 'info-nav-link',
+                        'data-node-id': w.person_id,
+                    }, w.writer)
+                    : w.writer;
+                ul.appendChild(this._el('li', null, inner));
+            }
+            contentElement.appendChild(this._el('div', { className: 'info-section' },
+                this._el('h4', null, 'Songwriters'),
+                ul));
         }
 
-        // Lyrics
         if (song.lyrics) {
-            html += `<div class="info-section"><h4>Lyrics</h4><pre class="info-lyrics">${esc(song.lyrics)}</pre></div>`;
+            contentElement.appendChild(this._el('div', { className: 'info-section' },
+                this._el('h4', null, 'Lyrics'),
+                this._el('pre', { className: 'info-lyrics' }, song.lyrics)));
         }
 
-        // Releases (clickable)
         const releases = song.releases || [];
         if (releases.length > 0) {
-            html += `<div class="info-section"><h4>Appears On</h4><ul class="info-list">`;
-            releases.forEach(r => {
-                const date = r.release_date ? ` (${esc(r.release_date.substring(0, 4))})` : '';
-                html += `<li><a href="#" class="info-nav-link song-release-link" data-release-id="${esc(r.release_id)}">${esc(r.release)}</a>${date}</li>`;
-            });
-            html += `</ul></div>`;
+            const ul = this._el('ul', { className: 'info-list' });
+            for (const r of releases) {
+                const link = this._el('a', {
+                    href: '#',
+                    className: 'info-nav-link song-release-link',
+                    'data-release-id': r.release_id,
+                }, r.release);
+                const dateText = r.release_date
+                    ? ` (${r.release_date.substring(0, 4)})`
+                    : null;
+                ul.appendChild(this._el('li', null, link, dateText));
+            }
+            contentElement.appendChild(this._el('div', { className: 'info-section' },
+                this._el('h4', null, 'Appears On'),
+                ul));
         }
 
-        contentElement.innerHTML = html;
-
-        // Attach click handlers for songwriter navigation
+        // Songwriter nav handlers
         this.callbacks.attachNavLinkListeners(contentElement);
 
-        // Attach click handlers for release navigation
+        // Release nav handlers (specific to .song-release-link — separate flow)
         contentElement.querySelectorAll('.song-release-link').forEach(link => {
             link.addEventListener('click', (e) => {
                 e.preventDefault();
@@ -95,18 +170,14 @@ export class InfoPanelRenderer {
     }
 
     renderCurateRow(op) {
-        const row = document.createElement('div');
-        row.className = 'curate-row';
-        row.dataset.hash = op.hash;
-
         const typeNames = {
             21: 'Release', 30: 'Add Claim', 31: 'Edit Claim',
-            40: 'Vote', 41: 'Like', 50: 'Finalize', 60: 'Merge'
+            40: 'Vote', 41: 'Like', 50: 'Finalize', 60: 'Merge',
         };
         const typeName = typeNames[op.type] || `Type ${op.type}`;
 
         const summary = op.event_summary;
-        let title = summary?.release_name || summary?.group_name || op.hash.substring(0, 12) + '...';
+        const title = summary?.release_name || summary?.group_name || op.hash.substring(0, 12) + '...';
 
         const ts = op.ts ? new Date(op.ts + 'Z') : null;
         const timeStr = ts ? ts.toLocaleDateString([], { month: 'short', day: 'numeric' }) : '';
@@ -114,37 +185,39 @@ export class InfoPanelRenderer {
         const tally = op.tally || { up_weight: 0, down_weight: 0, up_voter_count: 0, down_voter_count: 0 };
         const netScore = tally.up_weight - tally.down_weight;
 
-        const statusClass = op.finalized ? 'curate-status--finalized' : '';
-        const statusLabel = op.finalized ? 'Finalized' : 'Open';
+        const scoreClass = 'curate-score' +
+            (netScore > 0 ? ' curate-score--positive'
+                : netScore < 0 ? ' curate-score--negative' : '');
 
-        row.innerHTML = `
-            <div class="curate-row__header">
-                <span class="curate-type-badge curate-type-${op.type}">${typeName}</span>
-                <span class="curate-row__title">${this.escapeHtml(title)}</span>
-                <span class="curate-row__time">${timeStr}</span>
-            </div>
-            <div class="curate-row__author">by ${this.escapeHtml(op.author)}</div>
-            <div class="curate-row__tally">
-                <span class="curate-score ${netScore > 0 ? 'curate-score--positive' : netScore < 0 ? 'curate-score--negative' : ''}">
-                    ${netScore > 0 ? '+' : ''}${netScore}
-                </span>
-                <span class="curate-voters">
-                    <span class="curate-up">${tally.up_weight} (${tally.up_voter_count})</span>
-                    /
-                    <span class="curate-down">${tally.down_weight} (${tally.down_voter_count})</span>
-                </span>
-                <span class="curate-status ${statusClass}">${statusLabel}</span>
-            </div>
-        `;
+        const row = this._el('div', {
+            className: 'curate-row',
+            dataset: { hash: op.hash },
+        },
+            this._el('div', { className: 'curate-row__header' },
+                this._el('span', { className: `curate-type-badge curate-type-${op.type}` }, typeName),
+                this._el('span', { className: 'curate-row__title' }, title),
+                this._el('span', { className: 'curate-row__time' }, timeStr)),
+            this._el('div', { className: 'curate-row__author' }, 'by ', op.author),
+            this._el('div', { className: 'curate-row__tally' },
+                this._el('span', { className: scoreClass },
+                    (netScore > 0 ? '+' : '') + netScore),
+                this._el('span', { className: 'curate-voters' },
+                    this._el('span', { className: 'curate-up' },
+                        `${tally.up_weight} (${tally.up_voter_count})`),
+                    ' / ',
+                    this._el('span', { className: 'curate-down' },
+                        `${tally.down_weight} (${tally.down_voter_count})`)),
+                this._el('span', {
+                    className: 'curate-status' + (op.finalized ? ' curate-status--finalized' : ''),
+                }, op.finalized ? 'Finalized' : 'Open'))
+        );
 
-        // Click row to show detail (not the vote buttons)
         row.addEventListener('click', () => this.callbacks.selectCurateOperation(op));
-
         return row;
     }
 
     renderCurateDetail(container, resp, op) {
-        container.innerHTML = '';
+        container.replaceChildren();
 
         const operation = resp.operation || {};
         const tally = resp.tally || { up_weight: 0, down_weight: 0, up_voter_count: 0, down_voter_count: 0 };
@@ -153,81 +226,65 @@ export class InfoPanelRenderer {
         const viewerVote = resp.viewer_vote;
 
         // Header
-        const header = document.createElement('div');
-        header.className = 'curate-detail-header';
-        header.innerHTML = `
-            <h3>${this.escapeHtml(operation.type_name || 'Operation')}</h3>
-            <div class="curate-detail-meta">
-                <span>by ${this.escapeHtml(operation.author || '?')}</span>
-                <span>${operation.ts ? new Date(operation.ts + 'Z').toLocaleString() : ''}</span>
-                <span>${operation.finalized ? 'Finalized' : 'Open'}</span>
-            </div>
-        `;
-        container.appendChild(header);
+        container.appendChild(this._el('div', { className: 'curate-detail-header' },
+            this._el('h3', null, operation.type_name || 'Operation'),
+            this._el('div', { className: 'curate-detail-meta' },
+                this._el('span', null, 'by ', operation.author || '?'),
+                this._el('span', null, operation.ts ? new Date(operation.ts + 'Z').toLocaleString() : ''),
+                this._el('span', null, operation.finalized ? 'Finalized' : 'Open'))));
 
-        // Voting controls in detail pane
+        // Voting controls
         const netScore = tally.up_weight - tally.down_weight;
-        const votingDiv = document.createElement('div');
-        votingDiv.className = 'curate-detail-voting';
-        votingDiv.innerHTML = `
-            <span class="curate-score ${netScore > 0 ? 'curate-score--positive' : netScore < 0 ? 'curate-score--negative' : ''}">
-                ${netScore > 0 ? '+' : ''}${netScore}
-            </span>
-            <span class="curate-voters">
-                <span class="curate-up">${tally.up_weight} (${tally.up_voter_count})</span> /
-                <span class="curate-down">${tally.down_weight} (${tally.down_voter_count})</span>
-            </span>
-        `;
+        const scoreClass = 'curate-score' +
+            (netScore > 0 ? ' curate-score--positive'
+                : netScore < 0 ? ' curate-score--negative' : '');
+
+        const votingDiv = this._el('div', { className: 'curate-detail-voting' },
+            this._el('span', { className: scoreClass },
+                (netScore > 0 ? '+' : '') + netScore),
+            this._el('span', { className: 'curate-voters' },
+                this._el('span', { className: 'curate-up' },
+                    `${tally.up_weight} (${tally.up_voter_count})`),
+                ' / ',
+                this._el('span', { className: 'curate-down' },
+                    `${tally.down_weight} (${tally.down_voter_count})`)));
 
         if (!operation.finalized) {
-            const upBtn = document.createElement('button');
-            upBtn.className = 'curate-vote-btn curate-vote-up' + (viewerVote?.val === 1 ? ' curate-vote-btn--active' : '');
-            upBtn.textContent = viewerVote?.val === 1 ? 'Upvoted' : 'Upvote';
-            upBtn.addEventListener('click', (e) => {
-                e.stopPropagation();
-                this.callbacks.voteFromDetail(op, 1);
-            });
+            votingDiv.appendChild(this._el('button', {
+                className: 'curate-vote-btn curate-vote-up' + (viewerVote?.val === 1 ? ' curate-vote-btn--active' : ''),
+                onClick: (e) => { e.stopPropagation(); this.callbacks.voteFromDetail(op, 1); },
+            }, viewerVote?.val === 1 ? 'Upvoted' : 'Upvote'));
 
-            const downBtn = document.createElement('button');
-            downBtn.className = 'curate-vote-btn curate-vote-down' + (viewerVote?.val === -1 ? ' curate-vote-btn--active' : '');
-            downBtn.textContent = viewerVote?.val === -1 ? 'Downvoted' : 'Downvote';
-            downBtn.addEventListener('click', (e) => {
-                e.stopPropagation();
-                this.callbacks.voteFromDetail(op, -1);
-            });
-
-            votingDiv.appendChild(upBtn);
-            votingDiv.appendChild(downBtn);
+            votingDiv.appendChild(this._el('button', {
+                className: 'curate-vote-btn curate-vote-down' + (viewerVote?.val === -1 ? ' curate-vote-btn--active' : ''),
+                onClick: (e) => { e.stopPropagation(); this.callbacks.voteFromDetail(op, -1); },
+            }, viewerVote?.val === -1 ? 'Downvoted' : 'Downvote'));
         }
         container.appendChild(votingDiv);
 
         // Body: type-specific rendering
-        const body = document.createElement('div');
-        body.className = 'curate-detail-body';
+        const body = this._el('div', { className: 'curate-detail-body' });
 
         if (detail?.type === 'release_bundle') {
             this.renderReleaseBundleDetail(body, detail);
         } else if (detail?.type === 'add_claim' || detail?.type === 'edit_claim') {
             this.renderClaimDetail(body, detail);
         } else if (detail) {
-            body.innerHTML = '<p style="color:#888">Unsupported operation type for detailed view.</p>';
+            body.appendChild(this._el('p', { style: 'color:#888' },
+                'Unsupported operation type for detailed view.'));
         } else {
-            body.innerHTML = '<p style="color:#888">No event payload available.</p>';
+            body.appendChild(this._el('p', { style: 'color:#888' },
+                'No event payload available.'));
         }
 
         container.appendChild(body);
 
         // Raw JSON toggle
         if (event) {
-            const rawSection = document.createElement('div');
-            rawSection.className = 'curate-raw-json';
-            rawSection.innerHTML = `
-                <details>
-                    <summary>Raw Event JSON</summary>
-                    <pre>${this.escapeHtml(JSON.stringify(event, null, 2))}</pre>
-                </details>
-            `;
-            body.appendChild(rawSection);
+            body.appendChild(this._el('div', { className: 'curate-raw-json' },
+                this._el('details', null,
+                    this._el('summary', null, 'Raw Event JSON'),
+                    this._el('pre', null, JSON.stringify(event, null, 2)))));
         }
     }
 
@@ -235,162 +292,231 @@ export class InfoPanelRenderer {
         const rel = detail.release || {};
 
         // Release info section
-        const releaseSection = document.createElement('div');
-        releaseSection.className = 'curate-section';
-        let releaseHtml = '<h4>Release</h4>';
-        releaseHtml += this.detailField('Name', rel.name);
-        if (rel.release_date) releaseHtml += this.detailField('Date', rel.release_date);
-        if (rel.format) releaseHtml += this.detailField('Format', rel.format);
-        if (rel.alt_names?.length) releaseHtml += this.detailField('Alt Names', rel.alt_names.join(', '));
-        if (rel.master_id) releaseHtml += this.detailField('Master ID', rel.master_id);
-        releaseSection.innerHTML = releaseHtml;
+        const releaseSection = this._el('div', { className: 'curate-section' },
+            this._el('h4', null, 'Release'));
+        const releaseFields = [
+            this.detailField('Name', rel.name),
+            rel.release_date && this.detailField('Date', rel.release_date),
+            rel.format && this.detailField('Format', rel.format),
+            rel.alt_names?.length && this.detailField('Alt Names', rel.alt_names.join(', ')),
+            rel.master_id && this.detailField('Master ID', rel.master_id),
+        ];
+        for (const f of releaseFields) if (f) releaseSection.appendChild(f);
         container.appendChild(releaseSection);
 
         // Labels
         if (rel.labels?.length) {
-            const labelsSection = document.createElement('div');
-            labelsSection.className = 'curate-section';
-            let html = '<h4>Labels</h4>';
+            const labelsSection = this._el('div', { className: 'curate-section' },
+                this._el('h4', null, 'Labels'));
             for (const l of rel.labels) {
-                html += `<div class="curate-field-value">${this.escapeHtml(l.name)}${l.label_id ? ` <span style="color:#666">(${this.escapeHtml(l.label_id)})</span>` : ''}</div>`;
+                const idSuffix = l.label_id
+                    ? [' ', this._el('span', { style: 'color:#666' }, `(${l.label_id})`)]
+                    : null;
+                labelsSection.appendChild(this._el('div', { className: 'curate-field-value' },
+                    l.name, idSuffix));
             }
-            labelsSection.innerHTML = html;
             container.appendChild(labelsSection);
         }
 
         // Groups
         if (detail.groups?.length) {
-            const groupsSection = document.createElement('div');
-            groupsSection.className = 'curate-section';
-            let html = '<h4>Groups</h4>';
+            const groupsSection = this._el('div', { className: 'curate-section' },
+                this._el('h4', null, 'Groups'));
             for (const g of detail.groups) {
-                html += `<div class="curate-field-value" style="margin-bottom:6px"><strong>${this.escapeHtml(g.name)}</strong>${g.group_id ? ` <span style="color:#666">(${this.escapeHtml(g.group_id)})</span>` : ''}</div>`;
+                const idSuffix = g.group_id
+                    ? [' ', this._el('span', { style: 'color:#666' }, `(${g.group_id})`)]
+                    : null;
+                groupsSection.appendChild(this._el('div', {
+                    className: 'curate-field-value',
+                    style: 'margin-bottom:6px',
+                },
+                    this._el('strong', null, g.name), idSuffix));
+
                 if (g.members?.length) {
-                    html += '<div class="curate-person-list">';
+                    const list = this._el('div', { className: 'curate-person-list' });
                     for (const m of g.members) {
-                        html += `<span class="curate-person-chip">${this.escapeHtml(m.name)}${m.roles?.length ? ` <span class="curate-role">${this.escapeHtml(m.roles.join(', '))}</span>` : ''}</span>`;
+                        const roleSuffix = m.roles?.length
+                            ? [' ', this._el('span', { className: 'curate-role' }, m.roles.join(', '))]
+                            : null;
+                        list.appendChild(this._el('span', { className: 'curate-person-chip' },
+                            m.name, roleSuffix));
                     }
-                    html += '</div>';
+                    groupsSection.appendChild(list);
                 }
             }
-            groupsSection.innerHTML = html;
             container.appendChild(groupsSection);
         }
 
         // Release guests
         if (rel.guests?.length) {
-            const guestsSection = document.createElement('div');
-            guestsSection.className = 'curate-section';
-            let html = '<h4>Release Personnel</h4><div class="curate-person-list">';
+            const guestsSection = this._el('div', { className: 'curate-section' },
+                this._el('h4', null, 'Release Personnel'));
+            const list = this._el('div', { className: 'curate-person-list' });
             for (const g of rel.guests) {
-                html += `<span class="curate-person-chip">${this.escapeHtml(g.name)}${g.roles?.length ? ` <span class="curate-role">${this.escapeHtml(g.roles.join(', '))}</span>` : ''}</span>`;
+                const roleSuffix = g.roles?.length
+                    ? [' ', this._el('span', { className: 'curate-role' }, g.roles.join(', '))]
+                    : null;
+                list.appendChild(this._el('span', { className: 'curate-person-chip' },
+                    g.name, roleSuffix));
             }
-            html += '</div>';
-            guestsSection.innerHTML = html;
+            guestsSection.appendChild(list);
             container.appendChild(guestsSection);
         }
 
         // Tracklist / tracks
         if (detail.tracks?.length) {
-            const tracksSection = document.createElement('div');
-            tracksSection.className = 'curate-section';
-            let html = '<h4>Tracks</h4>';
+            const tracksSection = this._el('div', { className: 'curate-section' },
+                this._el('h4', null, 'Tracks'));
             for (let i = 0; i < detail.tracks.length; i++) {
                 const t = detail.tracks[i];
                 const pos = detail.tracklist?.[i]?.position || (i + 1);
-                html += '<div class="curate-track-item">';
-                html += `<div class="curate-track-title">${pos}. ${this.escapeHtml(t.title || 'Untitled')}${t.track_id ? ` <span style="color:#666;font-size:10px">${this.escapeHtml(t.track_id)}</span>` : ''}</div>`;
+                const item = this._el('div', { className: 'curate-track-item' });
+
+                const titleEl = this._el('div', { className: 'curate-track-title' },
+                    `${pos}. ${t.title || 'Untitled'}`,
+                    t.track_id
+                        ? [' ', this._el('span', { style: 'color:#666;font-size:10px' }, t.track_id)]
+                        : null);
+                item.appendChild(titleEl);
 
                 // Track groups
                 if (t.performed_by_groups?.length) {
                     for (const g of t.performed_by_groups) {
-                        html += `<div class="curate-track-credits">Group: ${this.escapeHtml(g.name)}`;
-                        if (g.members?.length) {
-                            html += ' (' + g.members.map(m => this.escapeHtml(m.name)).join(', ') + ')';
-                        }
-                        html += '</div>';
+                        const memberText = g.members?.length
+                            ? ` (${g.members.map(m => m.name).join(', ')})`
+                            : '';
+                        item.appendChild(this._el('div', { className: 'curate-track-credits' },
+                            'Group: ', g.name, memberText));
                     }
                 }
 
                 // Track guests
                 if (t.guests?.length) {
-                    html += `<div class="curate-track-credits">Guests: ${t.guests.map(g => this.escapeHtml(g.name) + (g.roles?.length ? ` (${this.escapeHtml(g.roles.join(', '))})` : '')).join(', ')}</div>`;
+                    const guestsText = t.guests.map(g => {
+                        const roles = g.roles?.length ? ` (${g.roles.join(', ')})` : '';
+                        return `${g.name}${roles}`;
+                    }).join(', ');
+                    item.appendChild(this._el('div', { className: 'curate-track-credits' },
+                        'Guests: ', guestsText));
                 }
 
                 // Producers
                 if (t.producers?.length) {
-                    html += `<div class="curate-track-credits">Producers: ${t.producers.map(p => this.escapeHtml(p.name)).join(', ')}</div>`;
+                    item.appendChild(this._el('div', { className: 'curate-track-credits' },
+                        'Producers: ', t.producers.map(p => p.name).join(', ')));
                 }
 
                 // Cover / Samples
                 if (t.cover_of_song_id) {
-                    html += `<div class="curate-track-credits">Cover of: ${this.escapeHtml(t.cover_of_song_id)}</div>`;
+                    item.appendChild(this._el('div', { className: 'curate-track-credits' },
+                        'Cover of: ', t.cover_of_song_id));
                 }
                 if (t.samples?.length) {
-                    html += `<div class="curate-track-credits">Samples: ${t.samples.map(s => this.escapeHtml(s.sampled_track_id || '')).join(', ')}</div>`;
+                    item.appendChild(this._el('div', { className: 'curate-track-credits' },
+                        'Samples: ', t.samples.map(s => s.sampled_track_id || '').join(', ')));
                 }
 
-                // Listen links
+                // Listen links — anchor href is a URL; routing through Text nodes
+                // means the URL never reaches an HTML parser, so a `javascript:`
+                // URI in the data would still bind to href via setAttribute.
+                // Validate scheme to prevent that.
                 if (t.listen_links?.length) {
-                    html += `<div class="curate-track-credits">Listen: ${t.listen_links.map(l => `<a href="${this.escapeHtml(l)}" target="_blank" style="color:#5c9cef">${this.escapeHtml(new URL(l).hostname)}</a>`).join(', ')}</div>`;
+                    const linkRow = this._el('div', { className: 'curate-track-credits' }, 'Listen: ');
+                    const safeLinks = t.listen_links.filter(l => /^https?:\/\//i.test(l));
+                    safeLinks.forEach((url, idx) => {
+                        if (idx > 0) linkRow.appendChild(document.createTextNode(', '));
+                        let host;
+                        try { host = new URL(url).hostname; } catch { host = url; }
+                        linkRow.appendChild(this._el('a', {
+                            href: url,
+                            target: '_blank',
+                            style: 'color:#5c9cef',
+                        }, host));
+                    });
+                    if (safeLinks.length > 0) item.appendChild(linkRow);
                 }
 
-                html += '</div>';
+                tracksSection.appendChild(item);
             }
-            tracksSection.innerHTML = html;
             container.appendChild(tracksSection);
         }
 
         // Songs
         if (detail.songs?.length) {
-            const songsSection = document.createElement('div');
-            songsSection.className = 'curate-section';
-            let html = '<h4>Songs (Compositions)</h4>';
+            const songsSection = this._el('div', { className: 'curate-section' },
+                this._el('h4', null, 'Songs (Compositions)'));
             for (const s of detail.songs) {
-                html += `<div class="curate-field-value" style="margin-bottom:4px">${this.escapeHtml(s.title)}`;
-                if (s.writers?.length) {
-                    html += ` — ${s.writers.map(w => this.escapeHtml(w.name)).join(', ')}`;
-                }
-                html += '</div>';
+                const writerText = s.writers?.length
+                    ? ' — ' + s.writers.map(w => w.name).join(', ')
+                    : null;
+                songsSection.appendChild(this._el('div', {
+                    className: 'curate-field-value',
+                    style: 'margin-bottom:4px',
+                }, s.title, writerText));
             }
-            songsSection.innerHTML = html;
             container.appendChild(songsSection);
         }
 
-        // Sources
+        // Sources — same javascript: URI guard as listen_links above.
         if (detail.sources?.length) {
-            const srcSection = document.createElement('div');
-            srcSection.className = 'curate-section';
-            let html = '<h4>Sources</h4>';
+            const srcSection = this._el('div', { className: 'curate-section' },
+                this._el('h4', null, 'Sources'));
             for (const s of detail.sources) {
-                html += `<div class="curate-field-value"><a href="${this.escapeHtml(s.url || '')}" target="_blank" style="color:#5c9cef">${this.escapeHtml(s.url || '')}</a></div>`;
+                const url = s.url || '';
+                const safe = /^https?:\/\//i.test(url);
+                srcSection.appendChild(this._el('div', { className: 'curate-field-value' },
+                    safe
+                        ? this._el('a', { href: url, target: '_blank', style: 'color:#5c9cef' }, url)
+                        : url));
             }
-            srcSection.innerHTML = html;
             container.appendChild(srcSection);
         }
     }
 
     renderClaimDetail(container, detail) {
-        const section = document.createElement('div');
-        section.className = 'curate-section';
-        let html = `<h4>${detail.type === 'edit_claim' ? 'Edit Claim' : 'Add Claim'}</h4>`;
-        if (detail.target_type) html += this.detailField('Target Type', detail.target_type);
-        if (detail.target_id) html += this.detailField('Target ID', detail.target_id);
-        if (detail.field) html += this.detailField('Field', detail.field);
+        const section = this._el('div', { className: 'curate-section' },
+            this._el('h4', null, detail.type === 'edit_claim' ? 'Edit Claim' : 'Add Claim'));
+
+        const fields = [
+            detail.target_type && this.detailField('Target Type', detail.target_type),
+            detail.target_id && this.detailField('Target ID', detail.target_id),
+            detail.field && this.detailField('Field', detail.field),
+        ];
+
         if (detail.value !== undefined && detail.value !== null) {
-            const valStr = typeof detail.value === 'object' ? JSON.stringify(detail.value, null, 2) : String(detail.value);
-            html += this.detailField('Value', valStr);
+            const valStr = typeof detail.value === 'object'
+                ? JSON.stringify(detail.value, null, 2)
+                : String(detail.value);
+            fields.push(this.detailField('Value', valStr));
         }
-        if (detail.source) html += this.detailField('Source', typeof detail.source === 'object' ? detail.source.url || JSON.stringify(detail.source) : detail.source);
-        section.innerHTML = html;
+        if (detail.source) {
+            const sourceStr = typeof detail.source === 'object'
+                ? (detail.source.url || JSON.stringify(detail.source))
+                : detail.source;
+            fields.push(this.detailField('Source', sourceStr));
+        }
+
+        for (const f of fields) if (f) section.appendChild(f);
         container.appendChild(section);
     }
 
+    /**
+     * Build a labeled detail field. Now returns an Element instead of an HTML
+     * string (it used to be string-concatenated into innerHTML). Returns null
+     * for falsy values so callers can `if (f) parent.appendChild(f)`.
+     */
     detailField(label, value) {
-        if (!value) return '';
-        return `<div class="curate-field"><span class="curate-field-label">${this.escapeHtml(label)}</span><span class="curate-field-value">${this.escapeHtml(String(value))}</span></div>`;
+        if (!value) return null;
+        return this._el('div', { className: 'curate-field' },
+            this._el('span', { className: 'curate-field-label' }, label),
+            this._el('span', { className: 'curate-field-value' }, String(value)));
     }
 
+    /**
+     * Legacy HTML-encoder. No internal callers after PR-L; retained because
+     * external code (MusicGraph render methods that haven't yet moved here)
+     * may still depend on it.
+     */
     escapeHtml(str) {
         const div = document.createElement('div');
         div.textContent = str;


### PR DESCRIPTION
## Summary

Refactor `InfoPanelRenderer` to eliminate all `innerHTML` string concatenation patterns in favor of explicit DOM construction via a new `_el()` helper method. This removes implicit XSS surfaces by routing all user-supplied values through `Text` nodes (auto-escaped by the browser) instead of interpolating them into HTML strings.

## Key Changes

- **Added `_el()` helper method**: A DOM builder that constructs elements with attributes and children in a single call. Supports className, dataset, event listeners, and style attributes. Automatically wraps strings/numbers in Text nodes for safe escaping.

- **Converted all rendering methods**: Replaced `innerHTML +=` patterns and manual `document.createElement()` chains with `_el()` calls in:
  - `renderSongDetails()` — songwriters, lyrics, releases sections
  - `renderCurateRow()` — operation row with type badge, title, tally, status
  - `renderCurateDetail()` — header, voting controls, body sections
  - `renderReleaseBundleDetail()` — release info, labels, groups, tracks, songs, sources
  - `renderClaimDetail()` — claim fields
  - `detailField()` — now returns an Element instead of an HTML string

- **Updated `detailField()` signature**: Changed return type from `string` to `HTMLElement | null`. Callers now append the element directly instead of concatenating HTML strings.

- **Security improvements**:
  - User values (names, titles, URLs) now flow through Text nodes, preventing HTML injection
  - Added validation for listen links and source URLs to filter out non-http(s) schemes
  - Removed reliance on `escapeHtml()` for rendering (retained as legacy for external callers)

- **Snapshot updates**: Removed whitespace-only text nodes between sibling block elements (semantically identical but byte-different). Snapshots updated to reflect the new compact HTML output.

## Implementation Details

- The `_el()` helper flattens nested arrays of children, allowing conditional children to be inlined: `cond && _el(...)`
- Event listeners are attached via `onClick` attribute (converted to lowercase `click` event)
- Style attributes are set as strings (not objects) to maintain byte-stable snapshots across jsdom normalization
- All user-supplied data now bypasses HTML parsing, eliminating the XSS surface that existed in every `escapeHtml()` call site

https://claude.ai/code/session_013ya9NZB4C9fESFwAiSi9DF