### PR TITLE
Extract renderGroupDetails, renderPersonDetails, renderReleaseDetails to InfoPanelRenderer

### DIFF
--- a/backend/test/visualization/__snapshots__/musicGraphRemainingRenders.snapshot.test.js.snap
+++ b/backend/test/visualization/__snapshots__/musicGraphRemainingRenders.snapshot.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Stage K · renderGroupDetails full group with photo, dates, members, bio, trivia → snapshot 1`] = `"<div class="info-photo"><img src="https://example.com/beatles.jpg" alt="The Beatles"></div>[edit:group/g:beatles/photo]<p class="info-meta"><strong>Active:</strong> 1960–1970</p>[edit:group/g:beatles/formed_date][edit:group/g:beatles/disbanded_date]<div class="info-section"><h4>Members</h4><ul class="info-list"><li><a href="#" class="info-nav-link" data-node-id="p:lennon"><strong>John Lennon</strong></a> - Vocals, Guitar</li><li><a href="#" class="info-nav-link" data-node-id="p:mccartney"><strong>Paul McCartney</strong></a> - Vocals, Bass</li><li><strong>Anonymous &amp; Co.</strong></li></ul></div><div class="info-section"><h4>Biography</h4><p>English rock band formed in &lt;Liverpool&gt;</p></div>[edit:group/g:beatles/bio]<div class="info-section"><h4>Trivia</h4><p>Best-selling music act of all time</p></div>[edit:group/g:beatles/trivia]"`;
+
+exports[`Stage K · renderGroupDetails minimal group (only name) → snapshot 1`] = `"[edit:group/g:solo/photo][edit:group/g:solo/formed_date][edit:group/g:solo/disbanded_date][edit:group/g:solo/bio][edit:group/g:solo/trivia]"`;
+
+exports[`Stage K · renderPersonDetails full person with photo, color, city, groups, bio, trivia → snapshot 1`] = `
+"<div class="info-photo"><img src="https://example.com/lennon.jpg" alt="John Lennon"></div>[edit:person/p:lennon/photo]<div class="info-color-row">
+            <strong>Color:</strong>
+            <span class="info-color-swatch" style="background:#ff0000"></span>
+            <span class="info-color-hex">#ff0000</span>
+            <input type="color" class="color-picker-input" data-node-id="p:lennon" value="#ff0000" title="Edit color">
+        </div><p class="info-meta"><strong>Location:</strong> Liverpool</p>[edit:person/p:lennon/city]<div class="info-section"><h4>Groups</h4><ul class="info-list"><li><a href="#" class="info-nav-link" data-node-id="g:beatles"><strong>The Beatles</strong></a> - Vocals</li><li><a href="#" class="info-nav-link" data-node-id="g:pob"><strong>Plastic Ono Band</strong></a></li><li><strong>Quarrymen</strong></li></ul></div><div class="info-section"><h4>Biography</h4><p>Singer, songwriter, peace activist</p></div>[edit:person/p:lennon/bio]<div class="info-section"><h4>Trivia</h4><p>Founded the Beatles in 1960</p></div>[edit:person/p:lennon/trivia]"
+`;
+
+exports[`Stage K · renderPersonDetails minimal person (only name) defaults color to #888888 → snapshot 1`] = `
+"[edit:person/p:anon/photo]<div class="info-color-row">
+            <strong>Color:</strong>
+            <span class="info-color-swatch" style="background:#888888"></span>
+            <span class="info-color-hex">#888888</span>
+            <input type="color" class="color-picker-input" data-node-id="p:anon" value="#888888" title="Edit color">
+        </div>[edit:person/p:anon/city][edit:person/p:anon/bio][edit:person/p:anon/trivia]"
+`;
+
+exports[`Stage K · renderReleaseDetails full release with art, date, format, labels, groups, tracks, guests, liner notes → snapshot 1`] = `"<div class="info-photo"><img src="https://example.com/abbey.jpg" alt="Abbey Road"></div><p class="info-meta"><strong>Released:</strong> 1969-09-26</p><p class="info-meta"><strong>Format:</strong> LP</p><p class="info-meta"><strong>Label:</strong> Apple Records, EMI</p><div class="info-section"><h4>Performed by</h4><ul class="info-list"><li><strong>The Beatles</strong></li></ul></div><div class="info-section"><h4>Tracks</h4><ol class="info-list info-tracklist"><li>A-1. Come Together</li><li>A-2. Something</li><li>3. Untitled</li><li>B-1. Octopus's Garden</li></ol></div><div class="info-section"><h4>Guests</h4><ul class="info-list"><li><strong>Billy Preston</strong> - Organ, Electric Piano</li><li><strong>George Martin</strong></li></ul></div><div class="info-section"><h4>Liner Notes</h4><p>Recorded at EMI Studios</p></div>"`;
+
+exports[`Stage K · renderReleaseDetails minimal release (just name) → snapshot 1`] = `""`;

--- a/backend/test/visualization/__snapshots__/musicGraphRemainingRenders.snapshot.test.js.snap
+++ b/backend/test/visualization/__snapshots__/musicGraphRemainingRenders.snapshot.test.js.snap
@@ -4,23 +4,9 @@ exports[`Stage K · renderGroupDetails full group with photo, dates, members, bi
 
 exports[`Stage K · renderGroupDetails minimal group (only name) → snapshot 1`] = `"[edit:group/g:solo/photo][edit:group/g:solo/formed_date][edit:group/g:solo/disbanded_date][edit:group/g:solo/bio][edit:group/g:solo/trivia]"`;
 
-exports[`Stage K · renderPersonDetails full person with photo, color, city, groups, bio, trivia → snapshot 1`] = `
-"<div class="info-photo"><img src="https://example.com/lennon.jpg" alt="John Lennon"></div>[edit:person/p:lennon/photo]<div class="info-color-row">
-            <strong>Color:</strong>
-            <span class="info-color-swatch" style="background:#ff0000"></span>
-            <span class="info-color-hex">#ff0000</span>
-            <input type="color" class="color-picker-input" data-node-id="p:lennon" value="#ff0000" title="Edit color">
-        </div><p class="info-meta"><strong>Location:</strong> Liverpool</p>[edit:person/p:lennon/city]<div class="info-section"><h4>Groups</h4><ul class="info-list"><li><a href="#" class="info-nav-link" data-node-id="g:beatles"><strong>The Beatles</strong></a> - Vocals</li><li><a href="#" class="info-nav-link" data-node-id="g:pob"><strong>Plastic Ono Band</strong></a></li><li><strong>Quarrymen</strong></li></ul></div><div class="info-section"><h4>Biography</h4><p>Singer, songwriter, peace activist</p></div>[edit:person/p:lennon/bio]<div class="info-section"><h4>Trivia</h4><p>Founded the Beatles in 1960</p></div>[edit:person/p:lennon/trivia]"
-`;
+exports[`Stage K · renderPersonDetails full person with photo, color, city, groups, bio, trivia → snapshot 1`] = `"<div class="info-photo"><img src="https://example.com/lennon.jpg" alt="John Lennon"></div>[edit:person/p:lennon/photo]<div class="info-color-row"><strong>Color:</strong><span class="info-color-swatch" style="background:#ff0000"></span><span class="info-color-hex">#ff0000</span><input type="color" class="color-picker-input" data-node-id="p:lennon" value="#ff0000" title="Edit color"></div><p class="info-meta"><strong>Location:</strong> Liverpool</p>[edit:person/p:lennon/city]<div class="info-section"><h4>Groups</h4><ul class="info-list"><li><a href="#" class="info-nav-link" data-node-id="g:beatles"><strong>The Beatles</strong></a> - Vocals</li><li><a href="#" class="info-nav-link" data-node-id="g:pob"><strong>Plastic Ono Band</strong></a></li><li><strong>Quarrymen</strong></li></ul></div><div class="info-section"><h4>Biography</h4><p>Singer, songwriter, peace activist</p></div>[edit:person/p:lennon/bio]<div class="info-section"><h4>Trivia</h4><p>Founded the Beatles in 1960</p></div>[edit:person/p:lennon/trivia]"`;
 
-exports[`Stage K · renderPersonDetails minimal person (only name) defaults color to #888888 → snapshot 1`] = `
-"[edit:person/p:anon/photo]<div class="info-color-row">
-            <strong>Color:</strong>
-            <span class="info-color-swatch" style="background:#888888"></span>
-            <span class="info-color-hex">#888888</span>
-            <input type="color" class="color-picker-input" data-node-id="p:anon" value="#888888" title="Edit color">
-        </div>[edit:person/p:anon/city][edit:person/p:anon/bio][edit:person/p:anon/trivia]"
-`;
+exports[`Stage K · renderPersonDetails minimal person (only name) defaults color to #888888 → snapshot 1`] = `"[edit:person/p:anon/photo]<div class="info-color-row"><strong>Color:</strong><span class="info-color-swatch" style="background:#888888"></span><span class="info-color-hex">#888888</span><input type="color" class="color-picker-input" data-node-id="p:anon" value="#888888" title="Edit color"></div>[edit:person/p:anon/city][edit:person/p:anon/bio][edit:person/p:anon/trivia]"`;
 
 exports[`Stage K · renderReleaseDetails full release with art, date, format, labels, groups, tracks, guests, liner notes → snapshot 1`] = `"<div class="info-photo"><img src="https://example.com/abbey.jpg" alt="Abbey Road"></div><p class="info-meta"><strong>Released:</strong> 1969-09-26</p><p class="info-meta"><strong>Format:</strong> LP</p><p class="info-meta"><strong>Label:</strong> Apple Records, EMI</p><div class="info-section"><h4>Performed by</h4><ul class="info-list"><li><strong>The Beatles</strong></li></ul></div><div class="info-section"><h4>Tracks</h4><ol class="info-list info-tracklist"><li>A-1. Come Together</li><li>A-2. Something</li><li>3. Untitled</li><li>B-1. Octopus's Garden</li></ol></div><div class="info-section"><h4>Guests</h4><ul class="info-list"><li><strong>Billy Preston</strong> - Organ, Electric Piano</li><li><strong>George Martin</strong></li></ul></div><div class="info-section"><h4>Liner Notes</h4><p>Recorded at EMI Studios</p></div>"`;
 

--- a/backend/test/visualization/musicGraphRemainingRenders.snapshot.test.js
+++ b/backend/test/visualization/musicGraphRemainingRenders.snapshot.test.js
@@ -2,28 +2,24 @@
  * @jest-environment jsdom
  *
  * Stage K — Characterization snapshots for the three info-panel render
- * methods that stayed on MusicGraph after Stage J.
+ * methods originally on MusicGraph and now extracted into InfoPanelRenderer.
  *
  * Locks the DOM output of `renderGroupDetails`, `renderPersonDetails`,
- * and `renderReleaseDetails` so the upcoming move into InfoPanelRenderer
- * (Stage K.2) can be verified as a no-op move.
+ * and `renderReleaseDetails`. Tests were written against the unextracted
+ * methods on MusicGraph (PR-K1) and updated in PR-K2 to point at
+ * InfoPanelRenderer.js. The methods were also DOM-builder migrated as
+ * part of K2 (consistent with PR-L's InfoPanelRenderer rewrite); the
+ * snapshots updated for whitespace text-node normalization, all tag/
+ * attribute/text content byte-identical.
  *
- * Strategy mirrors the Stage H / J.x tests: AST-based source extraction +
- * `new Function(...)` compilation + isolated invoke. We re-read
- * MusicGraph.js on every run; any drift in a method body surfaces as a
- * snapshot diff.
+ * The group/person renderers call:
+ *   this.inlineEditor.editableRowHtml(...)        → HTML fragment string
+ *                                                   (inserted via insertAdjacentHTML)
+ *   this.inlineEditor.attach(container)
+ *   this.callbacks.attachNavLinkListeners(container)
  *
- * Notable differences from the existing musicGraphRenders snapshots
- * (which target InfoPanelRenderer):
- *   - These render methods use a hand-rolled `esc()` helper that only
- *     escapes &, <, " (NOT >). That asymmetry is a quirk of the current
- *     code and the snapshots lock it byte-for-byte. The K.2 extraction
- *     must preserve that quirk; switching to InfoPanelRenderer's
- *     `escapeHtml` (which uses textContent and escapes >) would diverge.
- *   - The group/person renderers call into `this.inlineEditor` (for
- *     edit-button HTML and listener wiring) and `this._attachNavLinkListeners`.
- *     The release renderer calls neither — it has no editable fields and
- *     no nav links yet.
+ * The release renderer doesn't touch inlineEditor or nav-link listeners
+ * (no editable fields, no nav links).
  */
 
 import { jest } from '@jest/globals';
@@ -34,7 +30,7 @@ import { parse } from '@babel/parser';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const SOURCE_PATH = resolve(__dirname, '../../../frontend/src/visualization/MusicGraph.js');
+const SOURCE_PATH = resolve(__dirname, '../../../frontend/src/visualization/InfoPanelRenderer.js');
 const SOURCE = readFileSync(SOURCE_PATH, 'utf8');
 
 // ---------------------------------------------------------------------------
@@ -62,7 +58,7 @@ const METHOD_INDEX = (() => {
 
 function extractMethod(name) {
     const node = METHOD_INDEX.get(name);
-    if (!node) throw new Error(`extractMethod: ${name} not found in MusicGraph.js`);
+    if (!node) throw new Error(`extractMethod: ${name} not found in InfoPanelRenderer.js`);
     const params = node.params.map(p => SOURCE.slice(p.start, p.end)).join(', ');
     const body = SOURCE.slice(node.body.start + 1, node.body.end - 1);
     const isAsync = !!node.async;
@@ -85,7 +81,11 @@ function compileMethod(name) {
 //   this.inlineEditor.editableRowHtml(type, id, field, value, label, isTextarea?)
 //                                              → HTML string for an edit button
 //   this.inlineEditor.attach(container)        → no-op in tests (spied)
-//   this._attachNavLinkListeners(container)    → no-op in tests (spied)
+//   this.callbacks.attachNavLinkListeners(container) → no-op in tests (spied)
+//   this._el(tag, attrs, ...children)          → DOM-builder helper (compiled
+//                                               from live source)
+//   this._appendEditableRow(parent, ...args)   → insertAdjacentHTML wrapper
+//                                               around editableRowHtml (compiled)
 //
 // editableRowHtml stub returns a deterministic placeholder so snapshots
 // don't churn against InlineEditor's exact HTML format. The placeholder
@@ -103,10 +103,16 @@ function makeStub() {
             }),
             attach: jest.fn(),
         },
-        _attachNavLinkListeners: jest.fn(),
+        callbacks: {
+            attachNavLinkListeners: jest.fn(),
+        },
         // Visible inspection points for tests that don't snapshot.
         _editorCalls: editorCalls,
     };
+    // Intra-cluster bindings — compile from live source so any drift in
+    // _el / _appendEditableRow flows through to the snapshot layer.
+    stub._el = compileMethod('_el').bind(stub);
+    stub._appendEditableRow = compileMethod('_appendEditableRow').bind(stub);
     return stub;
 }
 
@@ -172,7 +178,7 @@ describe('Stage K · renderGroupDetails', () => {
 
         // Sanity: editor + nav-link wiring fired exactly once each.
         expect(stub.inlineEditor.attach).toHaveBeenCalledWith(contentElement);
-        expect(stub._attachNavLinkListeners).toHaveBeenCalledWith(contentElement);
+        expect(stub.callbacks.attachNavLinkListeners).toHaveBeenCalledWith(contentElement);
 
         // editableRowHtml was called for: photo, formed_date, disbanded_date, bio, trivia (5 times)
         expect(stub._editorCalls.map(c => c.field)).toEqual([
@@ -279,7 +285,7 @@ describe('Stage K · renderPersonDetails', () => {
         expect(contentElement.innerHTML).toMatchSnapshot();
 
         expect(stub.inlineEditor.attach).toHaveBeenCalledWith(contentElement);
-        expect(stub._attachNavLinkListeners).toHaveBeenCalledWith(contentElement);
+        expect(stub.callbacks.attachNavLinkListeners).toHaveBeenCalledWith(contentElement);
         expect(stub._editorCalls.map(c => c.field)).toEqual([
             'photo', 'city', 'bio', 'trivia'
         ]);
@@ -350,7 +356,7 @@ describe('Stage K · renderReleaseDetails', () => {
 
         // Release renderer does NOT touch inlineEditor.attach or nav-link listeners.
         expect(stub.inlineEditor.attach).not.toHaveBeenCalled();
-        expect(stub._attachNavLinkListeners).not.toHaveBeenCalled();
+        expect(stub.callbacks.attachNavLinkListeners).not.toHaveBeenCalled();
         expect(stub._editorCalls).toEqual([]);
     });
 

--- a/backend/test/visualization/musicGraphRemainingRenders.snapshot.test.js
+++ b/backend/test/visualization/musicGraphRemainingRenders.snapshot.test.js
@@ -1,0 +1,478 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Stage K — Characterization snapshots for the three info-panel render
+ * methods that stayed on MusicGraph after Stage J.
+ *
+ * Locks the DOM output of `renderGroupDetails`, `renderPersonDetails`,
+ * and `renderReleaseDetails` so the upcoming move into InfoPanelRenderer
+ * (Stage K.2) can be verified as a no-op move.
+ *
+ * Strategy mirrors the Stage H / J.x tests: AST-based source extraction +
+ * `new Function(...)` compilation + isolated invoke. We re-read
+ * MusicGraph.js on every run; any drift in a method body surfaces as a
+ * snapshot diff.
+ *
+ * Notable differences from the existing musicGraphRenders snapshots
+ * (which target InfoPanelRenderer):
+ *   - These render methods use a hand-rolled `esc()` helper that only
+ *     escapes &, <, " (NOT >). That asymmetry is a quirk of the current
+ *     code and the snapshots lock it byte-for-byte. The K.2 extraction
+ *     must preserve that quirk; switching to InfoPanelRenderer's
+ *     `escapeHtml` (which uses textContent and escapes >) would diverge.
+ *   - The group/person renderers call into `this.inlineEditor` (for
+ *     edit-button HTML and listener wiring) and `this._attachNavLinkListeners`.
+ *     The release renderer calls neither — it has no editable fields and
+ *     no nav links yet.
+ */
+
+import { jest } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import { parse } from '@babel/parser';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SOURCE_PATH = resolve(__dirname, '../../../frontend/src/visualization/MusicGraph.js');
+const SOURCE = readFileSync(SOURCE_PATH, 'utf8');
+
+// ---------------------------------------------------------------------------
+// AST extraction.
+// ---------------------------------------------------------------------------
+
+const AST = parse(SOURCE, { sourceType: 'module', plugins: ['classProperties'] });
+
+const METHOD_INDEX = (() => {
+    const map = new Map();
+    function visit(node) {
+        if (!node || typeof node !== 'object') return;
+        if (node.type === 'ClassMethod' && node.key?.type === 'Identifier') {
+            map.set(node.key.name, node);
+        }
+        for (const key of Object.keys(node)) {
+            const v = node[key];
+            if (Array.isArray(v)) v.forEach(visit);
+            else if (v && typeof v === 'object' && v.type) visit(v);
+        }
+    }
+    visit(AST);
+    return map;
+})();
+
+function extractMethod(name) {
+    const node = METHOD_INDEX.get(name);
+    if (!node) throw new Error(`extractMethod: ${name} not found in MusicGraph.js`);
+    const params = node.params.map(p => SOURCE.slice(p.start, p.end)).join(', ');
+    const body = SOURCE.slice(node.body.start + 1, node.body.end - 1);
+    const isAsync = !!node.async;
+    return { params, body, isAsync };
+}
+
+function compileMethod(name) {
+    const { params, body, isAsync } = extractMethod(name);
+    const argNames = params.split(',').map(s => s.trim()).filter(Boolean);
+    if (isAsync) {
+        const AsyncFunction = (async function () {}).constructor;
+        return new AsyncFunction(...argNames, body);
+    }
+    // eslint-disable-next-line no-new-func
+    return new Function(...argNames, body);
+}
+
+// ---------------------------------------------------------------------------
+// Stub builder. The render methods reach into:
+//   this.inlineEditor.editableRowHtml(type, id, field, value, label, isTextarea?)
+//                                              → HTML string for an edit button
+//   this.inlineEditor.attach(container)        → no-op in tests (spied)
+//   this._attachNavLinkListeners(container)    → no-op in tests (spied)
+//
+// editableRowHtml stub returns a deterministic placeholder so snapshots
+// don't churn against InlineEditor's exact HTML format. The placeholder
+// records the call args, which is what the integration actually depends
+// on (the renderer trusts InlineEditor to produce sane edit buttons).
+// ---------------------------------------------------------------------------
+
+function makeStub() {
+    const editorCalls = [];
+    const stub = {
+        inlineEditor: {
+            editableRowHtml: jest.fn((type, id, field, value, label, isTextarea = false) => {
+                editorCalls.push({ type, id, field, value, label, isTextarea });
+                return `[edit:${type}/${id}/${field}]`;
+            }),
+            attach: jest.fn(),
+        },
+        _attachNavLinkListeners: jest.fn(),
+        // Visible inspection points for tests that don't snapshot.
+        _editorCalls: editorCalls,
+    };
+    return stub;
+}
+
+function makeContainer() {
+    document.body.innerHTML = '';
+    const titleElement = document.createElement('h2');
+    const contentElement = document.createElement('div');
+    document.body.appendChild(titleElement);
+    document.body.appendChild(contentElement);
+    return { titleElement, contentElement };
+}
+
+afterEach(() => { document.body.innerHTML = ''; });
+
+// ---------------------------------------------------------------------------
+// Drift guard.
+// ---------------------------------------------------------------------------
+
+describe('Stage K · drift guard', () => {
+    test.each([
+        ['renderGroupDetails',   '(group, titleElement, contentElement, nodeId)'],
+        ['renderPersonDetails',  '(person, titleElement, contentElement, nodeId)'],
+        ['renderReleaseDetails', '(release, titleElement, contentElement)'],
+    ])('method %s exists with signature %s', (name, sig) => {
+        const expected = sig.slice(1, -1).split(',').map(s => s.trim()).filter(Boolean).join(', ');
+        const { params } = extractMethod(name);
+        const actual = params.split(',').map(s => s.trim()).filter(Boolean).join(', ');
+        expect(actual).toBe(expected);
+    });
+
+    test('none of the three are async', () => {
+        for (const name of ['renderGroupDetails', 'renderPersonDetails', 'renderReleaseDetails']) {
+            expect(extractMethod(name).isAsync).toBe(false);
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// renderGroupDetails
+// ---------------------------------------------------------------------------
+
+describe('Stage K · renderGroupDetails', () => {
+    test('full group with photo, dates, members, bio, trivia → snapshot', () => {
+        const stub = makeStub();
+        const { titleElement, contentElement } = makeContainer();
+        const group = {
+            name: 'The Beatles',
+            photo: 'https://example.com/beatles.jpg',
+            formed_date: '1960',
+            disbanded_date: '1970',
+            members: [
+                { person: 'John Lennon', person_id: 'p:lennon', role: 'Vocals, Guitar' },
+                { person: 'Paul McCartney', person_id: 'p:mccartney', role: 'Vocals, Bass' },
+                { person: 'Anonymous & Co.' /* no person_id, has &amp; in name */ },
+            ],
+            bio: 'English rock band formed in <Liverpool>',
+            trivia: 'Best-selling music act of all time',
+        };
+        compileMethod('renderGroupDetails').call(stub, group, titleElement, contentElement, 'g:beatles');
+
+        expect(titleElement.textContent).toBe('The Beatles');
+        expect(contentElement.innerHTML).toMatchSnapshot();
+
+        // Sanity: editor + nav-link wiring fired exactly once each.
+        expect(stub.inlineEditor.attach).toHaveBeenCalledWith(contentElement);
+        expect(stub._attachNavLinkListeners).toHaveBeenCalledWith(contentElement);
+
+        // editableRowHtml was called for: photo, formed_date, disbanded_date, bio, trivia (5 times)
+        expect(stub._editorCalls.map(c => c.field)).toEqual([
+            'photo', 'formed_date', 'disbanded_date', 'bio', 'trivia'
+        ]);
+        expect(stub._editorCalls[3].isTextarea).toBe(true); // bio
+        expect(stub._editorCalls[4].isTextarea).toBe(true); // trivia
+    });
+
+    test('minimal group (only name) → snapshot', () => {
+        const stub = makeStub();
+        const { titleElement, contentElement } = makeContainer();
+        compileMethod('renderGroupDetails').call(
+            stub, { name: 'Solo Project' }, titleElement, contentElement, 'g:solo'
+        );
+
+        expect(titleElement.textContent).toBe('Solo Project');
+        expect(contentElement.innerHTML).toMatchSnapshot();
+    });
+
+    test('falls back to group_name when name absent', () => {
+        const stub = makeStub();
+        const { titleElement, contentElement } = makeContainer();
+        compileMethod('renderGroupDetails').call(
+            stub, { group_name: 'From group_name' }, titleElement, contentElement, 'g:1'
+        );
+        expect(titleElement.textContent).toBe('From group_name');
+    });
+
+    test('falls back to "Unknown Group" when both name fields absent', () => {
+        const stub = makeStub();
+        const { titleElement, contentElement } = makeContainer();
+        compileMethod('renderGroupDetails').call(stub, {}, titleElement, contentElement, 'g:unk');
+        expect(titleElement.textContent).toBe('Unknown Group');
+    });
+
+    test('description used as biography fallback when bio absent', () => {
+        const stub = makeStub();
+        const { titleElement, contentElement } = makeContainer();
+        compileMethod('renderGroupDetails').call(
+            stub,
+            { name: 'X', description: 'desc-fallback' },
+            titleElement, contentElement, 'g:x'
+        );
+        expect(contentElement.innerHTML).toContain('<h4>Biography</h4><p>desc-fallback</p>');
+    });
+
+    test('inferred-active range shown only when formed_date is empty', () => {
+        const stub = makeStub();
+        const { titleElement, contentElement } = makeContainer();
+        compileMethod('renderGroupDetails').call(
+            stub,
+            {
+                name: 'Inferred Band',
+                inferred_first_release_date: '1968',
+                inferred_last_release_date: '1972',
+            },
+            titleElement, contentElement, 'g:inf'
+        );
+        expect(contentElement.innerHTML).toContain('Active (from releases):');
+        expect(contentElement.innerHTML).toContain('1968–1972');
+    });
+
+    test('inferred-active hidden when claimed formed_date is present', () => {
+        const stub = makeStub();
+        const { titleElement, contentElement } = makeContainer();
+        compileMethod('renderGroupDetails').call(
+            stub,
+            {
+                name: 'Claimed Band',
+                formed_date: '1965',
+                inferred_first_release_date: '1968',
+            },
+            titleElement, contentElement, 'g:cl'
+        );
+        expect(contentElement.innerHTML).not.toContain('Active (from releases):');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// renderPersonDetails
+// ---------------------------------------------------------------------------
+
+describe('Stage K · renderPersonDetails', () => {
+    test('full person with photo, color, city, groups, bio, trivia → snapshot', () => {
+        const stub = makeStub();
+        const { titleElement, contentElement } = makeContainer();
+        const person = {
+            name: 'John Lennon',
+            photo: 'https://example.com/lennon.jpg',
+            color: '#ff0000',
+            city: 'Liverpool',
+            groups: [
+                { group: 'The Beatles', group_id: 'g:beatles', role: 'Vocals' },
+                { group: 'Plastic Ono Band', group_id: 'g:pob' },
+                { group: 'Quarrymen' /* no group_id */ },
+            ],
+            bio: 'Singer, songwriter, peace activist',
+            trivia: 'Founded the Beatles in 1960',
+        };
+        compileMethod('renderPersonDetails').call(stub, person, titleElement, contentElement, 'p:lennon');
+
+        expect(titleElement.textContent).toBe('John Lennon');
+        expect(contentElement.innerHTML).toMatchSnapshot();
+
+        expect(stub.inlineEditor.attach).toHaveBeenCalledWith(contentElement);
+        expect(stub._attachNavLinkListeners).toHaveBeenCalledWith(contentElement);
+        expect(stub._editorCalls.map(c => c.field)).toEqual([
+            'photo', 'city', 'bio', 'trivia'
+        ]);
+    });
+
+    test('minimal person (only name) defaults color to #888888 → snapshot', () => {
+        const stub = makeStub();
+        const { titleElement, contentElement } = makeContainer();
+        compileMethod('renderPersonDetails').call(
+            stub, { name: 'Anonymous' }, titleElement, contentElement, 'p:anon'
+        );
+        expect(contentElement.innerHTML).toMatchSnapshot();
+        expect(contentElement.innerHTML).toContain('background:#888888');
+    });
+
+    test('falls back to person_name when name absent', () => {
+        const stub = makeStub();
+        const { titleElement, contentElement } = makeContainer();
+        compileMethod('renderPersonDetails').call(
+            stub, { person_name: 'From person_name' }, titleElement, contentElement, 'p:1'
+        );
+        expect(titleElement.textContent).toBe('From person_name');
+    });
+
+    test('color picker input includes data-node-id and current color value', () => {
+        const stub = makeStub();
+        const { titleElement, contentElement } = makeContainer();
+        compileMethod('renderPersonDetails').call(
+            stub, { name: 'X', color: '#aabbcc' }, titleElement, contentElement, 'p:x'
+        );
+        expect(contentElement.innerHTML).toContain(
+            '<input type="color" class="color-picker-input" data-node-id="p:x" value="#aabbcc"'
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// renderReleaseDetails
+// ---------------------------------------------------------------------------
+
+describe('Stage K · renderReleaseDetails', () => {
+    test('full release with art, date, format, labels, groups, tracks, guests, liner notes → snapshot', () => {
+        const stub = makeStub();
+        const { titleElement, contentElement } = makeContainer();
+        const release = {
+            name: 'Abbey Road',
+            album_art: 'https://example.com/abbey.jpg',
+            release_date: '1969-09-26',
+            format: 'LP',
+            labels: [{ label: 'Apple Records' }, { name: 'EMI' }],
+            groups: [{ name: 'The Beatles' }],
+            tracks: [
+                { track: 'Come Together', track_number: 1, disc_number: 1, side: 'A' },
+                { title: 'Something', track_number: 2, disc_number: 1, side: 'A' },
+                { track: 'Octopus\'s Garden', track_number: 1, disc_number: 2, side: 'B' },
+                { /* no title */ track_number: 3 },
+            ],
+            guests: [
+                { name: 'Billy Preston', roles: ['Organ', 'Electric Piano'] },
+                { name: 'George Martin' /* no roles */ },
+            ],
+            liner_notes: 'Recorded at EMI Studios',
+        };
+        compileMethod('renderReleaseDetails').call(stub, release, titleElement, contentElement);
+
+        expect(titleElement.textContent).toBe('Abbey Road');
+        expect(contentElement.innerHTML).toMatchSnapshot();
+
+        // Release renderer does NOT touch inlineEditor.attach or nav-link listeners.
+        expect(stub.inlineEditor.attach).not.toHaveBeenCalled();
+        expect(stub._attachNavLinkListeners).not.toHaveBeenCalled();
+        expect(stub._editorCalls).toEqual([]);
+    });
+
+    test('minimal release (just name) → snapshot', () => {
+        const stub = makeStub();
+        const { titleElement, contentElement } = makeContainer();
+        compileMethod('renderReleaseDetails').call(
+            stub, { name: 'Untitled' }, titleElement, contentElement
+        );
+        expect(contentElement.innerHTML).toMatchSnapshot();
+        expect(contentElement.innerHTML).toBe('');
+    });
+
+    test('falls back to "Unknown Release" when name absent', () => {
+        const stub = makeStub();
+        const { titleElement, contentElement } = makeContainer();
+        compileMethod('renderReleaseDetails').call(stub, {}, titleElement, contentElement);
+        expect(titleElement.textContent).toBe('Unknown Release');
+    });
+
+    test('tracks sorted by disc_number then track_number (stable across discs)', () => {
+        const stub = makeStub();
+        const { titleElement, contentElement } = makeContainer();
+        compileMethod('renderReleaseDetails').call(
+            stub,
+            {
+                name: 'Multi-disc',
+                tracks: [
+                    { track: 'D2T1', track_number: 1, disc_number: 2 },
+                    { track: 'D1T2', track_number: 2, disc_number: 1 },
+                    { track: 'D1T1', track_number: 1, disc_number: 1 },
+                    { track: 'D2T2', track_number: 2, disc_number: 2 },
+                ],
+            },
+            titleElement, contentElement
+        );
+        const html = contentElement.innerHTML;
+        const order = ['D1T1', 'D1T2', 'D2T1', 'D2T2'];
+        let lastIdx = -1;
+        for (const name of order) {
+            const idx = html.indexOf(name);
+            expect(idx).toBeGreaterThan(lastIdx);
+            lastIdx = idx;
+        }
+    });
+
+    test('label name fallback: prefers .label, falls back to .name', () => {
+        const stub = makeStub();
+        const { titleElement, contentElement } = makeContainer();
+        compileMethod('renderReleaseDetails').call(
+            stub,
+            {
+                name: 'X',
+                labels: [{ label: 'PrefersLabel' }, { name: 'FallsBackToName' }],
+            },
+            titleElement, contentElement
+        );
+        expect(contentElement.innerHTML).toContain('PrefersLabel, FallsBackToName');
+    });
+
+    test('track title fallback: track > title > "Untitled"', () => {
+        const stub = makeStub();
+        const { titleElement, contentElement } = makeContainer();
+        compileMethod('renderReleaseDetails').call(
+            stub,
+            {
+                name: 'X',
+                tracks: [
+                    { track: 'A1', track_number: 1 },
+                    { title: 'A2-from-title', track_number: 2 },
+                    { /* no name */ track_number: 3 },
+                ],
+            },
+            titleElement, contentElement
+        );
+        const html = contentElement.innerHTML;
+        expect(html).toContain('A1');
+        expect(html).toContain('A2-from-title');
+        expect(html).toContain('Untitled');
+    });
+
+    test('side prefix prepended to track number when provided', () => {
+        const stub = makeStub();
+        const { titleElement, contentElement } = makeContainer();
+        compileMethod('renderReleaseDetails').call(
+            stub,
+            { name: 'X', tracks: [{ track: 'T', track_number: 3, side: 'A' }] },
+            titleElement, contentElement
+        );
+        expect(contentElement.innerHTML).toContain('A-3. T');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Escaping behavior — observable via the DOM round-trip.
+//
+// Note: even though the inline `esc()` helper in MusicGraph only encodes
+// &, <, " (NOT >), reading back `.innerHTML` re-serializes the parsed DOM
+// and the serializer escapes > to &gt; on the way out. So the externally-
+// observable behavior is "all four chars escaped", regardless of which
+// helper is used to produce the source string. The snapshots above lock
+// the round-tripped output — that's the guarantee K.2 must preserve.
+// ---------------------------------------------------------------------------
+
+describe('Stage K · escape behavior (round-trip)', () => {
+    test('renderGroupDetails: bio with all four special chars round-trips correctly', () => {
+        const stub = makeStub();
+        const { titleElement, contentElement } = makeContainer();
+        compileMethod('renderGroupDetails').call(
+            stub, { name: 'X', bio: 'a < b > c & "d"' }, titleElement, contentElement, 'g:x'
+        );
+        expect(contentElement.innerHTML).toContain('a &lt; b &gt; c &amp; "d"');
+    });
+
+    test('renderPersonDetails: color attr value with quote char survives the round-trip', () => {
+        const stub = makeStub();
+        const { titleElement, contentElement } = makeContainer();
+        compileMethod('renderPersonDetails').call(
+            stub, { name: 'X', color: '"#aabbcc"' }, titleElement, contentElement, 'p:x'
+        );
+        // " is escaped to &quot; in the source HTML so the attribute parses
+        // correctly; jsdom round-trips that as itself.
+        expect(contentElement.innerHTML).toContain('value="&quot;#aabbcc&quot;"');
+    });
+});

--- a/frontend/src/visualization/InfoPanelRenderer.js
+++ b/frontend/src/visualization/InfoPanelRenderer.js
@@ -21,6 +21,10 @@
  *
  * Public API:
  *   renderSongDetails(song, titleElement, contentElement)
+ *   renderGroupDetails(group, titleElement, contentElement, nodeId)
+ *   renderPersonDetails(person, titleElement, contentElement, nodeId)
+ *   renderReleaseDetails(release, titleElement, contentElement)
+ *   showReleaseDetailsInInfoPanel(release)              entry from overlay
  *   renderCurateRow(op)                             → HTMLElement
  *   renderCurateDetail(container, resp, op)
  *   renderReleaseBundleDetail(container, detail)
@@ -35,16 +39,21 @@
 
 export class InfoPanelRenderer {
     /**
-     * @param {Object} callbacks
-     * @param {(container: Element) => void} callbacks.attachNavLinkListeners
-     *   Wire `.info-nav-link` clicks to graph navigation. Lives on MusicGraph
-     *   because it's also used by render methods that haven't been moved here
-     *   (renderGroupDetails, renderPersonDetails).
-     * @param {(releaseId: string) => void} callbacks.navigateToRelease
-     * @param {(op: Object) => void} callbacks.selectCurateOperation
-     * @param {(op: Object, val: number) => void} callbacks.voteFromDetail
+     * @param {Object} deps
+     * @param {Object} deps.inlineEditor
+     *   InlineEditor instance — used by renderGroupDetails / renderPersonDetails
+     *   for the per-field edit buttons + the post-render listener wiring.
+     * @param {Object} deps.callbacks
+     * @param {(container: Element) => void} deps.callbacks.attachNavLinkListeners
+     *   Wire `.info-nav-link` clicks to graph navigation. Stays as a callback
+     *   because the implementation lives on MusicGraph (it calls into JIT
+     *   navigation which the renderer doesn't own).
+     * @param {(releaseId: string) => void} deps.callbacks.navigateToRelease
+     * @param {(op: Object) => void} deps.callbacks.selectCurateOperation
+     * @param {(op: Object, val: number) => void} deps.callbacks.voteFromDetail
      */
-    constructor(callbacks) {
+    constructor({ inlineEditor, callbacks }) {
+        this.inlineEditor = inlineEditor;
         this.callbacks = callbacks;
     }
 
@@ -167,6 +176,242 @@ export class InfoPanelRenderer {
                 if (releaseId) this.callbacks.navigateToRelease(releaseId);
             });
         });
+    }
+
+    /**
+     * Append the InlineEditor's edit-button HTML to a parent element.
+     * editableRowHtml returns a trusted, internally-escaped fragment;
+     * insertAdjacentHTML is the right pass-through (it's not user data).
+     */
+    _appendEditableRow(parent, ...args) {
+        parent.insertAdjacentHTML('beforeend', this.inlineEditor.editableRowHtml(...args));
+    }
+
+    /**
+     * Render Group details in info panel.
+     */
+    renderGroupDetails(group, titleElement, contentElement, nodeId) {
+        titleElement.textContent = group.name || group.group_name || 'Unknown Group';
+        contentElement.replaceChildren();
+
+        if (group.photo) {
+            contentElement.appendChild(this._el('div', { className: 'info-photo' },
+                this._el('img', { src: group.photo, alt: group.name })));
+        }
+        this._appendEditableRow(contentElement, 'group', nodeId, 'photo', group.photo || '', 'Photo URL');
+
+        const formed = group.formed_date || '';
+        const disbanded = group.disbanded_date || 'present';
+        if (formed) {
+            contentElement.appendChild(this._el('p', { className: 'info-meta' },
+                this._el('strong', null, 'Active:'), ` ${formed}–${disbanded}`));
+        }
+
+        // Show inferred active range from release dates when claimed dates are missing
+        const inferFirst = group.inferred_first_release_date;
+        const inferLast = group.inferred_last_release_date;
+        if (inferFirst && !formed) {
+            const inferRange = inferLast && inferLast !== inferFirst
+                ? `${inferFirst}–${inferLast}`
+                : inferFirst;
+            contentElement.appendChild(this._el('p', { className: 'info-meta info-inferred' },
+                this._el('strong', null, 'Active (from releases):'), ' ', inferRange));
+        }
+        this._appendEditableRow(contentElement, 'group', nodeId, 'formed_date', formed, 'Formed');
+        this._appendEditableRow(contentElement, 'group', nodeId, 'disbanded_date', group.disbanded_date || '', 'Disbanded');
+
+        if (group.members && group.members.length > 0) {
+            const list = this._el('ul', { className: 'info-list' });
+            for (const member of group.members) {
+                const role = member.role || '';
+                const personId = member.person_id || '';
+                const name = personId
+                    ? this._el('a', {
+                        href: '#', className: 'info-nav-link', 'data-node-id': personId,
+                    }, this._el('strong', null, member.person))
+                    : this._el('strong', null, member.person);
+                const roleSuffix = role ? ` - ${role}` : null;
+                list.appendChild(this._el('li', null, name, roleSuffix));
+            }
+            contentElement.appendChild(this._el('div', { className: 'info-section' },
+                this._el('h4', null, 'Members'), list));
+        }
+
+        if (group.bio || group.description) {
+            contentElement.appendChild(this._el('div', { className: 'info-section' },
+                this._el('h4', null, 'Biography'),
+                this._el('p', null, group.bio || group.description)));
+        }
+        this._appendEditableRow(contentElement, 'group', nodeId, 'bio', group.bio || group.description || '', 'Biography', true);
+
+        if (group.trivia) {
+            contentElement.appendChild(this._el('div', { className: 'info-section' },
+                this._el('h4', null, 'Trivia'),
+                this._el('p', null, group.trivia)));
+        }
+        this._appendEditableRow(contentElement, 'group', nodeId, 'trivia', group.trivia || '', 'Trivia', true);
+
+        this.inlineEditor.attach(contentElement);
+        this.callbacks.attachNavLinkListeners(contentElement);
+    }
+
+    /**
+     * Render Person details in info panel.
+     */
+    renderPersonDetails(person, titleElement, contentElement, nodeId) {
+        titleElement.textContent = person.name || person.person_name || 'Unknown Person';
+        contentElement.replaceChildren();
+
+        if (person.photo) {
+            contentElement.appendChild(this._el('div', { className: 'info-photo' },
+                this._el('img', { src: person.photo, alt: person.name })));
+        }
+        this._appendEditableRow(contentElement, 'person', nodeId, 'photo', person.photo || '', 'Photo URL');
+
+        const currentColor = person.color || '#888888';
+        contentElement.appendChild(this._el('div', { className: 'info-color-row' },
+            this._el('strong', null, 'Color:'),
+            this._el('span', {
+                className: 'info-color-swatch',
+                style: `background:${currentColor}`,
+            }),
+            this._el('span', { className: 'info-color-hex' }, currentColor),
+            this._el('input', {
+                type: 'color',
+                className: 'color-picker-input',
+                'data-node-id': nodeId,
+                value: currentColor,
+                title: 'Edit color',
+            })));
+
+        if (person.city) {
+            contentElement.appendChild(this._el('p', { className: 'info-meta' },
+                this._el('strong', null, 'Location:'), ' ', person.city));
+        }
+        this._appendEditableRow(contentElement, 'person', nodeId, 'city', person.city || '', 'City');
+
+        if (person.groups && person.groups.length > 0) {
+            const list = this._el('ul', { className: 'info-list' });
+            for (const grp of person.groups) {
+                const role = grp.role || '';
+                const groupId = grp.group_id || '';
+                const name = groupId
+                    ? this._el('a', {
+                        href: '#', className: 'info-nav-link', 'data-node-id': groupId,
+                    }, this._el('strong', null, grp.group))
+                    : this._el('strong', null, grp.group);
+                const roleSuffix = role ? ` - ${role}` : null;
+                list.appendChild(this._el('li', null, name, roleSuffix));
+            }
+            contentElement.appendChild(this._el('div', { className: 'info-section' },
+                this._el('h4', null, 'Groups'), list));
+        }
+
+        if (person.bio) {
+            contentElement.appendChild(this._el('div', { className: 'info-section' },
+                this._el('h4', null, 'Biography'),
+                this._el('p', null, person.bio)));
+        }
+        this._appendEditableRow(contentElement, 'person', nodeId, 'bio', person.bio || '', 'Biography', true);
+
+        if (person.trivia) {
+            contentElement.appendChild(this._el('div', { className: 'info-section' },
+                this._el('h4', null, 'Trivia'),
+                this._el('p', null, person.trivia)));
+        }
+        this._appendEditableRow(contentElement, 'person', nodeId, 'trivia', person.trivia || '', 'Trivia', true);
+
+        this.inlineEditor.attach(contentElement);
+        this.callbacks.attachNavLinkListeners(contentElement);
+    }
+
+    /**
+     * Display release details in the info viewer (called from overlay).
+     * Reads the `#info-title` and `#info-content` elements directly.
+     */
+    showReleaseDetailsInInfoPanel(release) {
+        const infoTitle = document.getElementById('info-title');
+        const infoContent = document.getElementById('info-content');
+        if (!infoTitle || !infoContent) return;
+        this.renderReleaseDetails(release, infoTitle, infoContent);
+    }
+
+    /**
+     * Render Release details in info panel.
+     */
+    renderReleaseDetails(release, titleElement, contentElement) {
+        titleElement.textContent = release.name || 'Unknown Release';
+        contentElement.replaceChildren();
+
+        if (release.album_art) {
+            contentElement.appendChild(this._el('div', { className: 'info-photo' },
+                this._el('img', { src: release.album_art, alt: release.name })));
+        }
+
+        if (release.release_date) {
+            contentElement.appendChild(this._el('p', { className: 'info-meta' },
+                this._el('strong', null, 'Released:'), ' ', release.release_date));
+        }
+
+        if (release.format) {
+            contentElement.appendChild(this._el('p', { className: 'info-meta' },
+                this._el('strong', null, 'Format:'), ' ', release.format));
+        }
+
+        // Labels
+        if (release.labels && release.labels.length > 0) {
+            const labelText = release.labels.map(l => l.label || l.name).join(', ');
+            contentElement.appendChild(this._el('p', { className: 'info-meta' },
+                this._el('strong', null, 'Label:'), ' ', labelText));
+        }
+
+        // Groups
+        if (release.groups && release.groups.length > 0) {
+            const list = this._el('ul', { className: 'info-list' });
+            for (const g of release.groups) {
+                list.appendChild(this._el('li', null, this._el('strong', null, g.name)));
+            }
+            contentElement.appendChild(this._el('div', { className: 'info-section' },
+                this._el('h4', null, 'Performed by'), list));
+        }
+
+        // Tracks
+        if (release.tracks && release.tracks.length > 0) {
+            const list = this._el('ol', { className: 'info-list info-tracklist' });
+            const sorted = [...release.tracks].sort((a, b) => {
+                const da = (a.disc_number || 1);
+                const db = (b.disc_number || 1);
+                if (da !== db) return da - db;
+                return (a.track_number || 0) - (b.track_number || 0);
+            });
+            for (const t of sorted) {
+                const side = t.side ? `${t.side}-` : '';
+                const num = t.track_number ? `${side}${t.track_number}. ` : '';
+                list.appendChild(this._el('li', null, `${num}${t.track || t.title || 'Untitled'}`));
+            }
+            contentElement.appendChild(this._el('div', { className: 'info-section' },
+                this._el('h4', null, 'Tracks'), list));
+        }
+
+        // Guests
+        if (release.guests && release.guests.length > 0) {
+            const list = this._el('ul', { className: 'info-list' });
+            for (const g of release.guests) {
+                const roles = g.roles && g.roles.length > 0
+                    ? ` - ${g.roles.join(', ')}`
+                    : null;
+                list.appendChild(this._el('li', null,
+                    this._el('strong', null, g.name), roles));
+            }
+            contentElement.appendChild(this._el('div', { className: 'info-section' },
+                this._el('h4', null, 'Guests'), list));
+        }
+
+        if (release.liner_notes) {
+            contentElement.appendChild(this._el('div', { className: 'info-section' },
+                this._el('h4', null, 'Liner Notes'),
+                this._el('p', null, release.liner_notes)));
+        }
     }
 
     renderCurateRow(op) {

--- a/frontend/src/visualization/MusicGraph.js
+++ b/frontend/src/visualization/MusicGraph.js
@@ -44,11 +44,33 @@ export class MusicGraph {
             onReleaseSelect: (details) => this._onOverlayReleaseSelect(details),
             onGuestClick: (personId) => this.navigateToNodeId(personId)
         });
+        // InlineEditor must be constructed BEFORE InfoPanelRenderer because
+        // renderGroupDetails / renderPersonDetails (now on InfoPanelRenderer)
+        // call this.inlineEditor.editableRowHtml + .attach. All InlineEditor
+        // callbacks resolve lazily (this.ht / this.loader / this.selectedNode
+        // are set later in this same ctor).
+        this.inlineEditor = new InlineEditor({
+            claimManager: this.claimManager,
+            callbacks: {
+                getSelectedNode: () => this.selectedNode,
+                refreshInfoPanel: (node) => this.updateInfoPanel(node),
+                plot: () => this.ht?.plot(),
+                patchRawGraphColor: (nodeId, color) => {
+                    const raw = this.loader?.rawGraph;
+                    if (!raw || !raw.nodes) return;
+                    const rawNode = raw.nodes.find(n => n.id === nodeId);
+                    if (rawNode) rawNode.color = color;
+                },
+            },
+        });
         this.infoPanel = new InfoPanelRenderer({
-            attachNavLinkListeners: (container) => this._attachNavLinkListeners(container),
-            navigateToRelease: (releaseId) => this._navigateToRelease(releaseId),
-            selectCurateOperation: (op) => this._selectCurateOperation(op),
-            voteFromDetail: (op, val) => this._curateVoteFromDetail(op, val)
+            inlineEditor: this.inlineEditor,
+            callbacks: {
+                attachNavLinkListeners: (container) => this._attachNavLinkListeners(container),
+                navigateToRelease: (releaseId) => this._navigateToRelease(releaseId),
+                selectCurateOperation: (op) => this._selectCurateOperation(op),
+                voteFromDetail: (op, val) => this._curateVoteFromDetail(op, val),
+            },
         });
         this.overlayPositioner = new OverlayPositioner({
             releaseOverlay: this.releaseOverlay,
@@ -108,23 +130,6 @@ export class MusicGraph {
             callbacks: {
                 plot: () => this.ht?.plot(),
                 updateOverlayPosition: () => this.overlayPositioner.updateOverlayPosition(),
-            },
-        });
-
-        // Inline editor (edit-button + color-picker flows). All callbacks
-        // resolve lazily — `this.ht` and `this.loader` are set later.
-        this.inlineEditor = new InlineEditor({
-            claimManager: this.claimManager,
-            callbacks: {
-                getSelectedNode: () => this.selectedNode,
-                refreshInfoPanel: (node) => this.updateInfoPanel(node),
-                plot: () => this.ht?.plot(),
-                patchRawGraphColor: (nodeId, color) => {
-                    const raw = this.loader?.rawGraph;
-                    if (!raw || !raw.nodes) return;
-                    const rawNode = raw.nodes.find(n => n.id === nodeId);
-                    if (rawNode) rawNode.color = color;
-                },
             },
         });
 
@@ -819,9 +824,9 @@ export class MusicGraph {
 
             const typeLower = type.toLowerCase();
             if (typeLower === 'group') {
-                this.renderGroupDetails(details, infoTitle, infoContent, nodeId);
+                this.infoPanel.renderGroupDetails(details, infoTitle, infoContent, nodeId);
             } else if (typeLower === 'person') {
-                this.renderPersonDetails(details, infoTitle, infoContent, nodeId);
+                this.infoPanel.renderPersonDetails(details, infoTitle, infoContent, nodeId);
             } else {
                 infoContent.innerHTML = `<p><strong>Type:</strong> ${type}</p>`;
             }
@@ -829,123 +834,6 @@ export class MusicGraph {
             console.error('Error fetching node details:', error);
             infoContent.innerHTML = '<p>Error loading details</p>';
         }
-    }
-
-    /**
-     * Render Group details in info panel
-     */
-    renderGroupDetails(group, titleElement, contentElement, nodeId) {
-        titleElement.textContent = group.name || group.group_name || 'Unknown Group';
-
-        const esc = v => String(v ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
-        let html = '';
-
-        if (group.photo) {
-            html += `<div class="info-photo"><img src="${esc(group.photo)}" alt="${esc(group.name)}" /></div>`;
-        }
-        html += this.inlineEditor.editableRowHtml('group', nodeId, 'photo', group.photo || '', 'Photo URL');
-
-        const formed = group.formed_date || '';
-        const disbanded = group.disbanded_date || 'present';
-        if (formed) {
-            html += `<p class="info-meta"><strong>Active:</strong> ${esc(formed)}\u2013${esc(disbanded)}</p>`;
-        }
-
-        // Show inferred active range from release dates when claimed dates are missing
-        const inferFirst = group.inferred_first_release_date;
-        const inferLast = group.inferred_last_release_date;
-        if (inferFirst && !formed) {
-            const inferRange = inferLast && inferLast !== inferFirst
-                ? `${esc(inferFirst)}\u2013${esc(inferLast)}`
-                : esc(inferFirst);
-            html += `<p class="info-meta info-inferred"><strong>Active (from releases):</strong> ${inferRange}</p>`;
-        }
-        html += this.inlineEditor.editableRowHtml('group', nodeId, 'formed_date', formed, 'Formed');
-        html += this.inlineEditor.editableRowHtml('group', nodeId, 'disbanded_date', group.disbanded_date || '', 'Disbanded');
-
-        if (group.members && group.members.length > 0) {
-            html += `<div class="info-section"><h4>Members</h4><ul class="info-list">`;
-            group.members.forEach(member => {
-                const role = member.role || '';
-                const personId = member.person_id || '';
-                if (personId) {
-                    html += `<li><a href="#" class="info-nav-link" data-node-id="${esc(personId)}"><strong>${esc(member.person)}</strong></a>${role ? ` - ${esc(role)}` : ''}</li>`;
-                } else {
-                    html += `<li><strong>${esc(member.person)}</strong>${role ? ` - ${esc(role)}` : ''}</li>`;
-                }
-            });
-            html += `</ul></div>`;
-        }
-
-        if (group.bio || group.description) {
-            html += `<div class="info-section"><h4>Biography</h4><p>${esc(group.bio || group.description)}</p></div>`;
-        }
-        html += this.inlineEditor.editableRowHtml('group', nodeId, 'bio', group.bio || group.description || '', 'Biography', true);
-
-        if (group.trivia) {
-            html += `<div class="info-section"><h4>Trivia</h4><p>${esc(group.trivia)}</p></div>`;
-        }
-        html += this.inlineEditor.editableRowHtml('group', nodeId, 'trivia', group.trivia || '', 'Trivia', true);
-
-        contentElement.innerHTML = html;
-        this.inlineEditor.attach(contentElement);
-        this._attachNavLinkListeners(contentElement);
-    }
-
-    /**
-     * Render Person details in info panel
-     */
-    renderPersonDetails(person, titleElement, contentElement, nodeId) {
-        titleElement.textContent = person.name || person.person_name || 'Unknown Person';
-
-        const esc = v => String(v ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
-        let html = '';
-
-        if (person.photo) {
-            html += `<div class="info-photo"><img src="${esc(person.photo)}" alt="${esc(person.name)}" /></div>`;
-        }
-        html += this.inlineEditor.editableRowHtml('person', nodeId, 'photo', person.photo || '', 'Photo URL');
-
-        const currentColor = person.color || '#888888';
-        html += `<div class="info-color-row">
-            <strong>Color:</strong>
-            <span class="info-color-swatch" style="background:${esc(currentColor)}"></span>
-            <span class="info-color-hex">${esc(currentColor)}</span>
-            <input type="color" class="color-picker-input" data-node-id="${esc(nodeId)}" value="${esc(currentColor)}" title="Edit color" />
-        </div>`;
-
-        if (person.city) {
-            html += `<p class="info-meta"><strong>Location:</strong> ${esc(person.city)}</p>`;
-        }
-        html += this.inlineEditor.editableRowHtml('person', nodeId, 'city', person.city || '', 'City');
-
-        if (person.groups && person.groups.length > 0) {
-            html += `<div class="info-section"><h4>Groups</h4><ul class="info-list">`;
-            person.groups.forEach(group => {
-                const role = group.role || '';
-                const groupId = group.group_id || '';
-                if (groupId) {
-                    html += `<li><a href="#" class="info-nav-link" data-node-id="${esc(groupId)}"><strong>${esc(group.group)}</strong></a>${role ? ` - ${esc(role)}` : ''}</li>`;
-                } else {
-                    html += `<li><strong>${esc(group.group)}</strong>${role ? ` - ${esc(role)}` : ''}</li>`;
-                }
-            });
-            html += `</ul></div>`;
-        }
-
-        if (person.bio) {
-            html += `<div class="info-section"><h4>Biography</h4><p>${esc(person.bio)}</p></div>`;
-        }
-        html += this.inlineEditor.editableRowHtml('person', nodeId, 'bio', person.bio || '', 'Biography', true);
-
-        if (person.trivia) {
-            html += `<div class="info-section"><h4>Trivia</h4><p>${esc(person.trivia)}</p></div>`;
-        }
-        html += this.inlineEditor.editableRowHtml('person', nodeId, 'trivia', person.trivia || '', 'Trivia', true);
-
-        contentElement.innerHTML = html;
-        this.inlineEditor.attach(contentElement);
-        this._attachNavLinkListeners(contentElement);
     }
 
     // ========== Release orbit overlay integration ==========
@@ -995,88 +883,7 @@ export class MusicGraph {
             return;
         }
 
-        this.showReleaseDetailsInInfoPanel(releaseDetails);
-    }
-
-    /**
-     * Display release details in the info viewer (called from overlay).
-     * @param {Object} release - Release details from API
-     */
-    showReleaseDetailsInInfoPanel(release) {
-        const infoTitle = document.getElementById('info-title');
-        const infoContent = document.getElementById('info-content');
-        if (!infoTitle || !infoContent) return;
-
-        this.renderReleaseDetails(release, infoTitle, infoContent);
-    }
-
-    /**
-     * Render Release details in info panel
-     */
-    renderReleaseDetails(release, titleElement, contentElement) {
-        titleElement.textContent = release.name || 'Unknown Release';
-
-        const esc = v => String(v ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
-        let html = '';
-
-        if (release.album_art) {
-            html += `<div class="info-photo"><img src="${esc(release.album_art)}" alt="${esc(release.name)}" /></div>`;
-        }
-
-        if (release.release_date) {
-            html += `<p class="info-meta"><strong>Released:</strong> ${esc(release.release_date)}</p>`;
-        }
-
-        if (release.format) {
-            html += `<p class="info-meta"><strong>Format:</strong> ${esc(release.format)}</p>`;
-        }
-
-        // Labels
-        if (release.labels && release.labels.length > 0) {
-            html += `<p class="info-meta"><strong>Label:</strong> ${release.labels.map(l => esc(l.label || l.name)).join(', ')}</p>`;
-        }
-
-        // Groups
-        if (release.groups && release.groups.length > 0) {
-            html += `<div class="info-section"><h4>Performed by</h4><ul class="info-list">`;
-            release.groups.forEach(g => {
-                html += `<li><strong>${esc(g.name)}</strong></li>`;
-            });
-            html += `</ul></div>`;
-        }
-
-        // Tracks
-        if (release.tracks && release.tracks.length > 0) {
-            html += `<div class="info-section"><h4>Tracks</h4><ol class="info-list info-tracklist">`;
-            const sorted = [...release.tracks].sort((a, b) => {
-                const da = (a.disc_number || 1);
-                const db = (b.disc_number || 1);
-                if (da !== db) return da - db;
-                return (a.track_number || 0) - (b.track_number || 0);
-            });
-            sorted.forEach(t => {
-                const side = t.side ? `${esc(t.side)}-` : '';
-                const num = t.track_number ? `${side}${t.track_number}. ` : '';
-                html += `<li>${num}${esc(t.track || t.title || 'Untitled')}</li>`;
-            });
-            html += `</ol></div>`;
-        }
-
-        // Guests
-        if (release.guests && release.guests.length > 0) {
-            html += `<div class="info-section"><h4>Guests</h4><ul class="info-list">`;
-            release.guests.forEach(g => {
-                const roles = g.roles && g.roles.length > 0 ? ` - ${g.roles.map(r => esc(r)).join(', ')}` : '';
-                html += `<li><strong>${esc(g.name)}</strong>${roles}</li>`;
-            });
-            html += `</ul></div>`;
-        }
-
-        if (release.liner_notes) {
-            html += `<div class="info-section"><h4>Liner Notes</h4><p>${esc(release.liner_notes)}</p></div>`;
-        }
-
-        contentElement.innerHTML = html;
+        this.infoPanel.showReleaseDetailsInInfoPanel(releaseDetails);
     }
 
     /**
@@ -1381,7 +1188,7 @@ export class MusicGraph {
             if (groups.length === 0) {
                 console.warn('No groups found for release:', releaseId);
                 // Fall back to showing release details in info panel
-                this.showReleaseDetailsInInfoPanel(release);
+                this.infoPanel.showReleaseDetailsInInfoPanel(release);
                 return;
             }
 
@@ -1467,7 +1274,7 @@ export class MusicGraph {
                 this.releaseOverlay.selectRelease(releaseId, releaseDetails);
 
                 // Show release details in info panel
-                this.showReleaseDetailsInInfoPanel(releaseDetails);
+                this.infoPanel.showReleaseDetailsInInfoPanel(releaseDetails);
             }
         });
     }


### PR DESCRIPTION
## Summary

Moves three info-panel rendering methods (`renderGroupDetails`, `renderPersonDetails`, `renderReleaseDetails`) from `MusicGraph` to `InfoPanelRenderer`, converting them from string-based HTML generation to DOM-builder pattern for consistency with the rest of the renderer.

## Key Changes

- **Extracted three render methods** from `MusicGraph` to `InfoPanelRenderer`:
  - `renderGroupDetails(group, titleElement, contentElement, nodeId)`
  - `renderPersonDetails(person, titleElement, contentElement, nodeId)`
  - `renderReleaseDetails(release, titleElement, contentElement)`
  - `showReleaseDetailsInInfoPanel(release)` (entry point from overlay)

- **Refactored HTML generation**: Converted from string concatenation with manual escaping to DOM-builder pattern using the existing `_el()` helper method, ensuring consistent escaping behavior and maintainability.

- **Updated InfoPanelRenderer constructor**: Now accepts `{ inlineEditor, callbacks }` object instead of just `callbacks`, allowing the renderer to call `inlineEditor.editableRowHtml()` and `inlineEditor.attach()` directly.

- **Added `_appendEditableRow()` helper**: Wraps `inlineEditor.editableRowHtml()` calls with `insertAdjacentHTML` for consistent edit-button insertion across group and person renderers.

- **Reordered MusicGraph initialization**: Moved `InlineEditor` construction before `InfoPanelRenderer` to ensure the inline editor is available when the renderer is instantiated (required for lazy callback resolution).

- **Updated call sites**: Changed `MusicGraph.updateInfoPanel()` to delegate to `this.infoPanel.renderGroupDetails()` and `this.infoPanel.renderPersonDetails()` instead of calling local methods.

- **Added comprehensive snapshot tests**: Created `musicGraphRemainingRenders.snapshot.test.js` with 484 lines of characterization tests that:
  - Extract and compile the three methods from live source via AST parsing
  - Lock DOM output via snapshots
  - Verify editor call sequences and nav-link listener wiring
  - Test edge cases (missing fields, fallbacks, escaping, sorting)
  - Include drift guards to detect signature changes

## Implementation Details

- All three methods now use `replaceChildren()` instead of `innerHTML =` for safer DOM manipulation
- Escaping is handled transparently by the DOM API (no manual `esc()` function needed)
- The snapshot tests stub `inlineEditor.editableRowHtml()` to return deterministic placeholders, allowing tests to verify call sequences without coupling to InlineEditor's exact HTML format
- Tests verify that `renderReleaseDetails` does NOT call `inlineEditor.attach()` or `attachNavLinkListeners()` (unlike the group/person renderers)

https://claude.ai/code/session_013ya9NZB4C9fESFwAiSi9DF